### PR TITLE
Added canonical import path obligation

### DIFF
--- a/engo.go
+++ b/engo.go
@@ -1,4 +1,4 @@
-package engo
+package engo // import "engo.io/engo"
 
 import (
 	"fmt"


### PR DESCRIPTION
One can now only import from `engo.io/engo`. 