### PR TITLE
Only master, and only latest go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
+branch: 
+    only:
+    - "master"
 language: go
 before_install:
     - sudo apt-get -qq update
     - sudo apt-get install -y libopenal-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev xorg-dev libgl1-mesa-dev
 go_import_path: engo.io/engo
 go:
-- 1.4
-- 1.5
-- 1.6
-- tip
+- 1.6.1


### PR DESCRIPTION
Not sure if `go1.6.1` or `go1.6` is valid. We'll just have to wait and see. 