### PR TITLE
Remove unnecessary conversions found by unconvert

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -50,7 +50,7 @@ func (c *Clock) Delta() float32 {
 
 // FPS is the amount of frames per second, computed every time a tick occurs at least a second after the previous update
 func (c *Clock) FPS() float32 {
-	return float32(c.fps)
+	return c.fps
 }
 
 // Time is the number of seconds the clock has been running

--- a/common/font.go
+++ b/common/font.go
@@ -128,7 +128,7 @@ func (f *Font) RenderNRGBA(text string) *image.NRGBA {
 	c.SetSrc(fg)
 
 	// Draw the text.
-	pt := fixed.P(0, int(yBearing))
+	pt := fixed.P(0, yBearing)
 	_, err := c.DrawString(text, pt)
 	if err != nil {
 		log.Println(err)


### PR DESCRIPTION
```
u@x1 ~/g/s/e/engo> unconvert engo.io/ecs engo.io/engo engo.io/engo/common
/home/u/goget/src/engo.io/engo/clock.go:53:16: unnecessary conversion
/home/u/goget/src/engo.io/engo/common/font.go:131:22: unnecessary conversion
```

https://github.com/mdempsky/unconvert