### PR TITLE
Slimmer engo clock internals

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -2,58 +2,62 @@ package engo
 
 import (
 	"time"
-
-	"github.com/luxengine/math"
 )
+
+// The amound of nano seconds in a second.
+const secondsInNano int64 = 1000000000
 
 // A Clock is a measurement built in `engo` to measure the actual frames per seconds (framerate).
 type Clock struct {
-	elapsed float32
-	delta   float32
-	fps     float32
-	frames  uint64
-	start   time.Time
-	frame   time.Time
+	counter   uint32
+	perSecond uint32
+
+	deltaStamp int64
+	elapsStamp int64
+	frameStamp int64
+	startStamp int64
 }
 
 // NewClock creates a new timer which allows you to measure ticks per seconds. Be sure to call `Tick()` whenever you
 // want a tick to occur - it does not automatically tick each frame.
 func NewClock() *Clock {
+	currStamp := time.Now().UnixNano()
+
 	clock := new(Clock)
-	clock.start = time.Now()
-	clock.Tick()
+	clock.frameStamp = currStamp
+	clock.startStamp = currStamp
 	return clock
 }
 
 // Tick indicates a new tick/frame has occurred.
 func (c *Clock) Tick() {
-	now := time.Now()
-	c.frames += 1
-	if !c.frame.IsZero() {
-		c.delta = float32(now.Sub(c.frame).Seconds())
-	}
+	currStamp := time.Now().UnixNano()
 
-	c.elapsed += c.delta
-	c.frame = now
+	c.counter += 1
 
-	if c.elapsed >= 1 {
-		c.fps = float32(c.frames)
-		c.elapsed = math.Mod(c.elapsed, 1)
-		c.frames = 0
+	c.deltaStamp = currStamp - c.frameStamp
+	c.frameStamp = currStamp
+
+	c.elapsStamp += c.deltaStamp
+	if secondsInNano <= c.elapsStamp {
+		c.elapsStamp %= secondsInNano
+		c.perSecond = c.counter
+		c.counter = 0
 	}
 }
 
 // Delta is the amount of seconds between the last tick and the one before that
 func (c *Clock) Delta() float32 {
-	return c.delta
+	return float32(float64(c.deltaStamp) / float64(secondsInNano))
 }
 
 // FPS is the amount of frames per second, computed every time a tick occurs at least a second after the previous update
-func (c *Clock) FPS() float32 {
-	return c.fps
+func (c *Clock) Fps() float32 {
+	return float32(c.perSecond)
 }
 
 // Time is the number of seconds the clock has been running
 func (c *Clock) Time() float32 {
-	return float32(time.Now().Sub(c.start).Seconds())
+	currStamp := time.Now().UnixNano()
+	return float32(float64(currStamp-c.startStamp) / float64(secondsInNano))
 }

--- a/clock.go
+++ b/clock.go
@@ -51,7 +51,7 @@ func (c *Clock) Delta() float32 {
 	return float32(float64(c.deltaStamp) / float64(secondsInNano))
 }
 
-// FPS is the amount of frames per second, computed every time a tick occurs at least a second after the previous update
+// Fps is the amount of frames per second, computed every time a tick occurs at least a second after the previous update
 func (c *Clock) Fps() float32 {
 	return float32(c.perSecond)
 }


### PR DESCRIPTION
- Short:
  * Faster tick method
  * Decrease structure size
  * Remove import of math package

- No more modulus on a float value, messy idea any way.

- No excessive divisions or multiplications inside Tick() or Time(), the Time internals are not optimal for this use case. (See links**)

- Size of the struct is now 40 bytes vs 72 bytes on the original, Time stores a extra pointer and caused padding inside the Clock struct. (Leaves room for 3 event pointers inside the 64 byte bounds of a cash line)

**Time.Sub()
https://golang.org/src/time/time.go?s=18822:18856#L618
**Time.UnixNano()
https://golang.org/src/time/time.go?s=24254:24284#L825
**Duration.Seconds()
https://golang.org/src/time/time.go?s=17832:17867#L579

***Note: In case Delta() is only called once or twice every frame this is fine, but when Delta() is called often it might be preferable to move the conversion to seconds back in to Tick() and sacrifice some memory for it.