### PR TITLE
Fix: Delta Time in the first two frames

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -46,8 +46,8 @@ func (c *Clock) Tick() {
 	}
 }
 
-// Resets all the clock values, when the main loop is paused this can be used to reset the delta time.
-func (c *Clock) Reset() {
+// Resets all the clock values.
+func (c *Clock) ResetAll() {
 	c.counter = 0
 	c.perSecond = 0
 
@@ -55,6 +55,16 @@ func (c *Clock) Reset() {
 	c.elapsStamp = 0
 	c.frameStamp = time.Now().UnixNano()
 	c.startStamp = c.frameStamp
+}
+
+// Resets the delta time of the clock.
+func (c *Clock) ResetDelta() {
+	c.frameStamp = time.Now().UnixNano()
+}
+
+// Resets the start time of the clock.
+func (c *Clock) ResetTimer() {
+	c.startStamp = time.Now().UnixNano()
 }
 
 // Delta is the amount of seconds between the last tick and the one before that

--- a/clock.go
+++ b/clock.go
@@ -46,27 +46,6 @@ func (c *Clock) Tick() {
 	}
 }
 
-// Resets all the clock values.
-func (c *Clock) ResetAll() {
-	c.counter = 0
-	c.perSecond = 0
-
-	c.deltaStamp = 0
-	c.elapsStamp = 0
-	c.frameStamp = time.Now().UnixNano()
-	c.startStamp = c.frameStamp
-}
-
-// Resets the delta time of the clock.
-func (c *Clock) ResetDelta() {
-	c.frameStamp = time.Now().UnixNano()
-}
-
-// Resets the start time of the clock.
-func (c *Clock) ResetTimer() {
-	c.startStamp = time.Now().UnixNano()
-}
-
 // Delta is the amount of seconds between the last tick and the one before that
 func (c *Clock) Delta() float32 {
 	return float32(float64(c.deltaStamp) / float64(secondsInNano))

--- a/clock.go
+++ b/clock.go
@@ -46,6 +46,17 @@ func (c *Clock) Tick() {
 	}
 }
 
+// Resets all the clock values, when the main loop is paused this can be used to reset the delta time.
+func (c *Clock) Reset() {
+	c.counter = 0
+	c.perSecond = 0
+
+	c.deltaStamp = 0
+	c.elapsStamp = 0
+	c.frameStamp = time.Now().UnixNano()
+	c.startStamp = c.frameStamp
+}
+
 // Delta is the amount of seconds between the last tick and the one before that
 func (c *Clock) Delta() float32 {
 	return float32(float64(c.deltaStamp) / float64(secondsInNano))

--- a/engo_glfw.go
+++ b/engo_glfw.go
@@ -241,6 +241,8 @@ func runLoop(defaultScene Scene, headless bool) {
 	RunPreparation(defaultScene)
 	ticker := time.NewTicker(time.Duration(int(time.Second) / opts.FPSLimit))
 
+	Time.Reset()
+
 Outer:
 	for {
 		select {

--- a/engo_glfw.go
+++ b/engo_glfw.go
@@ -220,8 +220,6 @@ func RunIteration() {
 // RunPreparation is called only once, and is called automatically when calling Open
 // It is only here for benchmarking in combination with OpenHeadlessNoRun
 func RunPreparation(defaultScene Scene) {
-	Time = NewClock()
-
 	// Default WorldBounds values
 	//WorldBounds.Max = Point{GameWidth(), GameHeight()}
 	// TODO: move this to appropriate location
@@ -241,7 +239,9 @@ func runLoop(defaultScene Scene, headless bool) {
 	RunPreparation(defaultScene)
 	ticker := time.NewTicker(time.Duration(int(time.Second) / opts.FPSLimit))
 
-	Time.ResetDelta()
+	// Keep the start of the clock close to the
+	// start of the main loop to avoid large delta's
+	Time = NewClock()
 
 Outer:
 	for {

--- a/engo_glfw.go
+++ b/engo_glfw.go
@@ -220,6 +220,8 @@ func RunIteration() {
 // RunPreparation is called only once, and is called automatically when calling Open
 // It is only here for benchmarking in combination with OpenHeadlessNoRun
 func RunPreparation(defaultScene Scene) {
+	Time = NewClock()
+
 	// Default WorldBounds values
 	//WorldBounds.Max = Point{GameWidth(), GameHeight()}
 	// TODO: move this to appropriate location
@@ -239,9 +241,8 @@ func runLoop(defaultScene Scene, headless bool) {
 	RunPreparation(defaultScene)
 	ticker := time.NewTicker(time.Duration(int(time.Second) / opts.FPSLimit))
 
-	// Keep the start of the clock close to the
-	// start of the main loop to avoid large delta's
-	Time = NewClock()
+	// Start tick, minimize the delta
+	Time.Tick()
 
 Outer:
 	for {

--- a/engo_glfw.go
+++ b/engo_glfw.go
@@ -241,7 +241,7 @@ func runLoop(defaultScene Scene, headless bool) {
 	RunPreparation(defaultScene)
 	ticker := time.NewTicker(time.Duration(int(time.Second) / opts.FPSLimit))
 
-	Time.Reset()
+	Time.ResetDelta()
 
 Outer:
 	for {

--- a/engo_glfw.go
+++ b/engo_glfw.go
@@ -196,6 +196,8 @@ func SetTitle(title string) {
 
 // RunIteration runs one iteration / frame
 func RunIteration() {
+	Time.Tick()
+
 	// First check for new keypresses
 	if !opts.HeadlessMode {
 		Input.update()
@@ -214,7 +216,6 @@ func RunIteration() {
 		window.SwapBuffers()
 	}
 
-	Time.Tick()
 }
 
 // RunPreparation is called only once, and is called automatically when calling Open

--- a/engo_js.go
+++ b/engo_js.go
@@ -224,8 +224,6 @@ func cancelAnimationFrame(id int) {
 }
 
 func RunPreparation() {
-	Time = NewClock()
-
 	dom.GetWindow().AddEventListener("onbeforeunload", false, func(e dom.Event) {
 		dom.GetWindow().Alert("You're closing")
 	})
@@ -236,7 +234,9 @@ func runLoop(defaultScene Scene, headless bool) {
 	RunPreparation()
 	ticker := time.NewTicker(time.Duration(int(time.Second) / opts.FPSLimit))
 
-	Time.ResetDelta()
+	// Keep the start of the clock close to the
+	// start of the main loop to avoid large delta's
+	Time = NewClock()
 
 Outer:
 	for {

--- a/engo_js.go
+++ b/engo_js.go
@@ -224,6 +224,8 @@ func cancelAnimationFrame(id int) {
 }
 
 func RunPreparation() {
+	Time = NewClock()
+
 	dom.GetWindow().AddEventListener("onbeforeunload", false, func(e dom.Event) {
 		dom.GetWindow().Alert("You're closing")
 	})
@@ -234,9 +236,8 @@ func runLoop(defaultScene Scene, headless bool) {
 	RunPreparation()
 	ticker := time.NewTicker(time.Duration(int(time.Second) / opts.FPSLimit))
 
-	// Keep the start of the clock close to the
-	// start of the main loop to avoid large delta's
-	Time = NewClock()
+	// Start tick, minimize the delta
+	Time.Tick()
 
 Outer:
 	for {

--- a/engo_js.go
+++ b/engo_js.go
@@ -236,7 +236,7 @@ func runLoop(defaultScene Scene, headless bool) {
 	RunPreparation()
 	ticker := time.NewTicker(time.Duration(int(time.Second) / opts.FPSLimit))
 
-	Time.Reset()
+	Time.ResetDelta()
 
 Outer:
 	for {

--- a/engo_js.go
+++ b/engo_js.go
@@ -235,6 +235,9 @@ func runLoop(defaultScene Scene, headless bool) {
 	SetScene(defaultScene, false)
 	RunPreparation()
 	ticker := time.NewTicker(time.Duration(int(time.Second) / opts.FPSLimit))
+
+	Time.Reset()
+
 Outer:
 	for {
 		select {

--- a/engo_js.go
+++ b/engo_js.go
@@ -199,9 +199,9 @@ func rafPolyfill() {
 }
 
 func RunIteration() {
-	currentWorld.Update(Time.Delta())
-	Input.update()
 	Time.Tick()
+	Input.update()
+	currentWorld.Update(Time.Delta())
 	// TODO: this may not work, and sky-rocket the FPS
 	//  requestAnimationFrame(func(dt float32) {
 	// 	currentWorld.Update(Time.Delta())

--- a/engo_mobile.go
+++ b/engo_mobile.go
@@ -99,7 +99,7 @@ func runLoop(defaultScene Scene, headless bool) {
 					images = glutil.NewImages(e.DrawContext.(mobilegl.Context))
 					fps = debug.NewFPS(images)
 
-					Time.Reset()
+					Time.ResetDelta()
 
 					// Let the device know we want to start painting :-)
 					a.Send(paint.Event{})

--- a/engo_mobile.go
+++ b/engo_mobile.go
@@ -164,6 +164,8 @@ func RunPreparation(defaultScene Scene) {
 
 // RunIteration runs one iteration / frame
 func RunIteration() {
+	Time.Tick()
+
 	if !opts.HeadlessMode {
 		Input.update()
 	}
@@ -171,7 +173,6 @@ func RunIteration() {
 	// Then update the world and all Systems
 	currentWorld.Update(Time.Delta())
 
-	Time.Tick()
 }
 
 // SetCursor changes the cursor - not yet implemented

--- a/engo_mobile.go
+++ b/engo_mobile.go
@@ -99,9 +99,8 @@ func runLoop(defaultScene Scene, headless bool) {
 					images = glutil.NewImages(e.DrawContext.(mobilegl.Context))
 					fps = debug.NewFPS(images)
 
-					// Keep the start of the clock close to the
-					// start of the main loop to avoid large delta's
-					Time = NewClock()
+					// Start tick, minimize the delta
+					Time.Tick()
 
 					// Let the device know we want to start painting :-)
 					a.Send(paint.Event{})
@@ -159,6 +158,7 @@ func runLoop(defaultScene Scene, headless bool) {
 // RunPreparation is called only once, and is called automatically when calling Open
 // It is only here for benchmarking in combination with OpenHeadlessNoRun
 func RunPreparation(defaultScene Scene) {
+	Time = NewClock()
 	SetScene(defaultScene, false)
 }
 

--- a/engo_mobile.go
+++ b/engo_mobile.go
@@ -99,6 +99,8 @@ func runLoop(defaultScene Scene, headless bool) {
 					images = glutil.NewImages(e.DrawContext.(mobilegl.Context))
 					fps = debug.NewFPS(images)
 
+					Time.Reset()
+
 					// Let the device know we want to start painting :-)
 					a.Send(paint.Event{})
 				case lifecycle.CrossOff:

--- a/engo_mobile.go
+++ b/engo_mobile.go
@@ -99,7 +99,9 @@ func runLoop(defaultScene Scene, headless bool) {
 					images = glutil.NewImages(e.DrawContext.(mobilegl.Context))
 					fps = debug.NewFPS(images)
 
-					Time.ResetDelta()
+					// Keep the start of the clock close to the
+					// start of the main loop to avoid large delta's
+					Time = NewClock()
 
 					// Let the device know we want to start painting :-)
 					a.Send(paint.Event{})
@@ -157,7 +159,6 @@ func runLoop(defaultScene Scene, headless bool) {
 // RunPreparation is called only once, and is called automatically when calling Open
 // It is only here for benchmarking in combination with OpenHeadlessNoRun
 func RunPreparation(defaultScene Scene) {
-	Time = NewClock()
 	SetScene(defaultScene, false)
 }
 


### PR DESCRIPTION
By doing the start tick before the main loop the frame stamp inside the clock gets reset and this will minimize the delta time on the first frame.

Moving the Tick inside loop to run first reduces the delta time on the first frame even more and ensures a normal delta time in the second frame. (Having the tick first is also a plus if fixed physics are added at some point)

Note: Reordered the main loop to be the same on all targets, there is no reason to have them update in a different order ? The web build still seems to build and run fine, I'm not able to test the mobile build.

---

Other options considered:

- Move the clock creation to the start of the loop ? The clock is public and can be accessed in the loading before the main loop starts. Having 'nil' dangling out of the public interface seems bad design.

- Adding a reset option ? It would almost be the same and works as well but tempting people to call a function like reset ...