### PR TITLE
Renamed SpaceComponent.Within to Contains, #313

### DIFF
--- a/common/collision.go
+++ b/common/collision.go
@@ -87,9 +87,9 @@ func (sc SpaceComponent) Corners() (points [4]engo.Point) {
 	return
 }
 
-// Within indicates whether or not the given point is within the rectangular plane as defined by this `SpaceComponent`.
+// Contains indicates whether or not the given point is within the rectangular plane as defined by this `SpaceComponent`.
 // If it's on the border, it is considered "not within".
-func (sc SpaceComponent) Within(p engo.Point) bool {
+func (sc SpaceComponent) Contains(p engo.Point) bool {
 	points := sc.Corners()
 
 	halfArea := (sc.Width * sc.Height) / 2

--- a/common/collision_test.go
+++ b/common/collision_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSpaceComponent_Within(t *testing.T) {
+func TestSpaceComponent_Contains(t *testing.T) {
 	space := SpaceComponent{Width: 100, Height: 100}
 	pass := []engo.Point{
 		engo.Point{10, 10},
@@ -37,11 +37,11 @@ func TestSpaceComponent_Within(t *testing.T) {
 	}
 
 	for _, p := range pass {
-		assert.True(t, space.Within(p), fmt.Sprintf("point %v should be within area", p))
+		assert.True(t, space.Contains(p), fmt.Sprintf("point %v should be within area", p))
 	}
 
 	for _, f := range fail {
-		assert.False(t, space.Within(f), fmt.Sprintf("point %v should not be within area", f))
+		assert.False(t, space.Contains(f), fmt.Sprintf("point %v should not be within area", f))
 	}
 }
 

--- a/common/mouse.go
+++ b/common/mouse.go
@@ -201,7 +201,7 @@ func (m *MouseSystem) Update(dt float32) {
 		// and if the Y-value is within range
 
 		if e.MouseComponent.Track || e.MouseComponent.startedDragging ||
-			e.SpaceComponent.Within(engo.Point{mx, my}) {
+			e.SpaceComponent.Contains(engo.Point{mx, my}) {
 
 			e.MouseComponent.Enter = !e.MouseComponent.Hovered
 			e.MouseComponent.Hovered = true


### PR DESCRIPTION
My first PR (ever, probably) so, please, check everything is fine. I ran `go test engo.io/engo` and `go test engo.io/engo/common` and they pass; hoping that's enough.

This should fix the issue in #313 regarding the SpaceComponent.Within renaming to Contains.