### PR TITLE
Fix Input behavior for web builds

### DIFF
--- a/demos/input/input.go
+++ b/demos/input/input.go
@@ -13,10 +13,18 @@ type DefaultScene struct{}
 func (*DefaultScene) Preload() {}
 func (*DefaultScene) Setup(w *ecs.World) {
 	w.AddSystem(&common.RenderSystem{})
+
+	// Register the input system responding
+	// to the input actions registered below.
 	w.AddSystem(&InputSystem{})
 
-	engo.Input.RegisterAxis("sideways", engo.AxisKeyPair{engo.A, engo.D})
+	// Register a button that is triggered when
+	// the state of 'Space' or 'Enter' is changed.
 	engo.Input.RegisterButton("action", engo.Space, engo.Enter)
+
+	// Register an axis where 'A' will return a
+	// negative value and 'D' returns a positive value.
+	engo.Input.RegisterAxis("sideways", engo.AxisKeyPair{engo.A, engo.D})
 }
 
 func (*DefaultScene) Type() string { return "Game" }
@@ -48,20 +56,21 @@ func (c *InputSystem) Remove(basic ecs.BasicEntity) {
 }
 
 func (c *InputSystem) Update(dt float32) {
-	if v := engo.Input.Axis("sideways").Value(); v != 0 {
-		fmt.Println(v)
-	}
+	// Look up the button once
+	btn := engo.Input.Button("action")
 
-	if btn := engo.Input.Button("action"); btn.Down() {
+	// And act on the current state
+	if btn.Down() {
 		fmt.Println("Still down!")
-	}
-
-	if btn := engo.Input.Button("action"); btn.JustPressed() {
+	} else if btn.JustPressed() {
 		fmt.Println("Key just pressed!")
+	} else if btn.JustReleased() {
+		fmt.Println("Key just released!")
 	}
 
-	if btn := engo.Input.Button("action"); btn.JustReleased() {
-		fmt.Println("Key just released!")
+	// Check the the axis value and act as required
+	if v := engo.Input.Axis("sideways").Value(); v != 0 {
+		fmt.Printf("Axis value: %.2f \n", v)
 	}
 }
 

--- a/demos/input/input.go
+++ b/demos/input/input.go
@@ -68,7 +68,7 @@ func (c *InputSystem) Update(dt float32) {
 		fmt.Println("Key just released!")
 	}
 
-	// Check the the axis value and act as required
+	// Check the axis value and act as required
 	if v := engo.Input.Axis("sideways").Value(); v != 0 {
 		fmt.Printf("Axis value: %.2f \n", v)
 	}

--- a/demos/input/input.go
+++ b/demos/input/input.go
@@ -52,8 +52,16 @@ func (c *InputSystem) Update(dt float32) {
 		fmt.Println(v)
 	}
 
+	if btn := engo.Input.Button("action"); btn.Down() {
+		fmt.Println("Still down!")
+	}
+
 	if btn := engo.Input.Button("action"); btn.JustPressed() {
-		fmt.Println("DOWN!")
+		fmt.Println("Key just pressed!")
+	}
+
+	if btn := engo.Input.Button("action"); btn.JustReleased() {
+		fmt.Println("Key just released!")
 	}
 }
 

--- a/engo_js.go
+++ b/engo_js.go
@@ -23,6 +23,7 @@ var (
 	gameWidth, gameHeight     float32
 	windowWidth, windowHeight float32
 	devicePixelRatio          float64
+	keyBuffer                 webKeyBuffer
 )
 
 func init() {
@@ -83,12 +84,12 @@ func CreateWindow(title string, width, height int, fullscreen bool, msaa int) {
 	})
 	w.AddEventListener("keydown", false, func(ev dom.Event) {
 		ke := ev.(*dom.KeyboardEvent)
-		Input.keys.Set(Key(ke.KeyCode), true)
+		keyBuffer.append(Key(ke.KeyCode), true)
 	})
 
 	w.AddEventListener("keyup", false, func(ev dom.Event) {
 		ke := ev.(*dom.KeyboardEvent)
-		Input.keys.Set(Key(ke.KeyCode), false)
+		keyBuffer.append(Key(ke.KeyCode), false)
 	})
 
 	w.AddEventListener("mousemove", false, func(ev dom.Event) {
@@ -201,6 +202,7 @@ func rafPolyfill() {
 func RunIteration() {
 	Time.Tick()
 	Input.update()
+	keyBuffer.update()
 	currentWorld.Update(Time.Delta())
 	// TODO: this may not work, and sky-rocket the FPS
 	//  requestAnimationFrame(func(dt float32) {
@@ -290,4 +292,30 @@ func SetCursor(c Cursor) {
 	case CursorHand:
 		document.Body().Style().Set("cursor", "hand")
 	}
+}
+
+// Key state for buffering, the buffering is needed
+// because of the async nature of most web browsers.
+type webKeyState struct {
+	key   Key
+	state bool
+}
+
+// Key state buffer used to buffer key events
+// until the game loop is ready to update them.
+type webKeyBuffer struct {
+	buffer []webKeyState
+}
+
+// Pushes the states on to the input and clears the buffer.
+func (b *webKeyBuffer) update() {
+	for _, st := range b.buffer {
+		Input.keys.Set(st.key, st.state)
+	}
+	b.buffer = b.buffer[:0]
+}
+
+// Adds a new key state to the buffer
+func (b *webKeyBuffer) append(k Key, s bool) {
+	b.buffer = append(b.buffer, webKeyState{key: k, state: s})
 }


### PR DESCRIPTION
Adds a web key buffer to the netgo build to deal with the async nature of web browsers and JavaScript. This resolves #342 in a simple way whiteout the need for massive changes.

Note: The resetting of the buffer leaves memory referenced that could leak when used without care. Sins this buffer is alive as long as the application is alive and the size is limited to the max amount of key events in +-16ms  this seems like a valid use case to avoid garbage generation.