### PR TITLE
MouseSystem now skips hidden entities

### DIFF
--- a/common/mouse.go
+++ b/common/mouse.go
@@ -194,6 +194,10 @@ func (m *MouseSystem) Update(dt float32) {
 				mx = engo.Input.Mouse.X
 				my = engo.Input.Mouse.Y
 			}
+
+			if e.RenderComponent.Hidden {
+				continue // skip hidden components
+			}
 		}
 
 		// If the Mouse component is a tracker we always update it


### PR DESCRIPTION
Currently, even though you hide something, it can receive hover/click events. 

This is unwanted, because you can click something that's explicitely hidden. If you want something invisible, but clickable, you should set alpha to 0, instead of defining `Hidden`, IMHO. 

@paked @otraore ?