### PR TITLE
Isometric Support

### DIFF
--- a/common/level.go
+++ b/common/level.go
@@ -93,8 +93,6 @@ func (lvl *Level)setupOrientation() error {
 			return
 		}
 		lvl.PointToMap = func(p engo.Point) (m *engo.Point) {
-			// m.X = p.X / float32(lvl.TileWidth) + p.Y / float32(lvl.TileWidth)
-			// m.Y = p.Y / float32(lvl.TileHeight) - p.X / float32(lvl.TileHeight)
 			m.X = (p.X + p.Y) / tw
 			m.Y = (p.Y - p.X) / th
 			return
@@ -111,6 +109,7 @@ func (lvl *Level)setupOrientation() error {
 			return
 		}
 		lvl.PointToMap = func(p engo.Point) (m *engo.Point) {
+			m = &engo.Point{}
 			m.Y = p.Y / hh
 			staggerX := float32(0) // no offset on even rows
 			if int(m.Y)%2 == 1 { // odd row?

--- a/common/level.go
+++ b/common/level.go
@@ -156,6 +156,8 @@ type tile struct {
 
 type tilesheet struct {
 	Image    *TextureResource
+	TileWidth int
+	TileHeight int
 	Firstgid int
 }
 
@@ -168,10 +170,10 @@ type layer struct {
 
 func createTileset(lvl *Level, sheets []*tilesheet) []*tile {
 	tileset := make([]*tile, 0)
-	tw := float32(lvl.TileWidth)
-	th := float32(lvl.TileHeight)
 
 	for _, sheet := range sheets {
+		tw := float32(sheet.TileWidth)
+		th := float32(sheet.TileHeight)
 		setWidth := sheet.Image.Width / tw
 		setHeight := sheet.Image.Height / th
 		totalTiles := int(setWidth * setHeight)

--- a/common/level.go
+++ b/common/level.go
@@ -223,9 +223,14 @@ func createLevelTiles(lvl *Level, layers []*layer, ts []*tile) []*TileLayer {
 				if tileIdx := int(mapping[idx]) - 1; tileIdx >= 0 {
 					t.Image = ts[tileIdx].Image
 					var px, py float32
+					hw := float32(lvl.TileWidth/2)
+					hh := float32(lvl.TileHeight/2)
 					if lvl.Orientation == "isometric" {
-						px = float32(x - i) * float32(lvl.TileWidth/2)
-						py = float32(x + i) * float32(lvl.TileHeight/2)
+						px = float32(x - i) * hw
+						py = float32(x + i) * hh
+					} else if lvl.Orientation == "staggered" {
+						px = (float32(x - i) * hw) + float32(i) * hw
+						py = (float32(x + i) * hh) + float32(i) * hh
 					} else {
 						px = float32(x * lvl.TileWidth)
 						py = float32(i * lvl.TileHeight)

--- a/common/level.go
+++ b/common/level.go
@@ -220,10 +220,15 @@ func createLevelTiles(lvl *Level, layers []*layer, ts []*tile) []*TileLayer {
 
 				if tileIdx := int(mapping[idx]) - 1; tileIdx >= 0 {
 					t.Image = ts[tileIdx].Image
-					t.Point = engo.Point{
-						float32(x * lvl.TileWidth),
-						float32(i * lvl.TileHeight),
+					var px, py float32
+					if lvl.Orientation == "isometric" {
+						px = float32(x - i) * float32(lvl.TileWidth/2)
+						py = float32(x + i) * float32(lvl.TileHeight/2)
+					} else {
+						px = float32(x * lvl.TileWidth)
+						py = float32(i * lvl.TileHeight)
 					}
+					t.Point = engo.Point{ px, py }
 				}
 				tilemap = append(tilemap, t)
 			}

--- a/common/level.go
+++ b/common/level.go
@@ -81,10 +81,8 @@ func (lvl *Level)setupOrientation() error {
 			return
 		}
 		lvl.PointToMap = func(p engo.Point) (m *engo.Point) {
-			// m.X = p.X / float32(lvl.TileWidth) + p.Y / float32(lvl.TileWidth)
-			// m.Y = p.Y / float32(lvl.TileHeight) - p.X / float32(lvl.TileHeight)
-			m.X = p.X / hw
-			m.Y = p.Y / hh
+			m.X = p.X / tw
+			m.Y = p.Y / th
 			return
 		}
 	} else if lvl.Orientation == "isometric" {

--- a/common/level.go
+++ b/common/level.go
@@ -215,7 +215,18 @@ func createLevelTiles(lvl *Level, layers []*layer, ts []*tile) []*TileLayer {
 		tileLayer := &TileLayer{}
 		mapping := layer.TileMapping
 
+		// Append tiles to map in the order they should be drawn
 		for i := 0; i < lvl.height; i++ {
+			// tile half-widths for isometric tilesets.
+			hw := float32(lvl.TileWidth/2)
+			hh := float32(lvl.TileHeight/2)
+
+			// Caclulate offset for staggered tilesets
+			staggerX := float32(0) // no offset for even rows
+			if i%2 == 0 {
+				staggerX = float32(lvl.TileWidth/2)
+			}
+
 			for x := 0; x < lvl.width; x++ {
 				idx := x + i*lvl.width
 				t := &tile{}
@@ -223,14 +234,12 @@ func createLevelTiles(lvl *Level, layers []*layer, ts []*tile) []*TileLayer {
 				if tileIdx := int(mapping[idx]) - 1; tileIdx >= 0 {
 					t.Image = ts[tileIdx].Image
 					var px, py float32
-					hw := float32(lvl.TileWidth/2)
-					hh := float32(lvl.TileHeight/2)
 					if lvl.Orientation == "isometric" {
 						px = float32(x - i) * hw
 						py = float32(x + i) * hh
 					} else if lvl.Orientation == "staggered" {
-						px = (float32(x - i) * hw) + float32(i) * hw
-						py = (float32(x + i) * hh) + float32(i) * hh
+						px = float32(x * lvl.TileWidth) + hw - staggerX
+						py = float32(i) * hh
 					} else {
 						px = float32(x * lvl.TileWidth)
 						py = float32(i * lvl.TileHeight)

--- a/common/tmx_level.go
+++ b/common/tmx_level.go
@@ -236,7 +236,7 @@ func createLevelFromTmx(tmxBytes []byte, tmxUrl string) (*Level, error) {
 	sort.Sort(ByFirstgid(tmxLevel.Tilesets))
 	ts := make([]*tilesheet, len(tmxLevel.Tilesets))
 	for i, tts := range tmxLevel.Tilesets {
-		ts[i] = &tilesheet{tts.Image, tts.Firstgid}
+		ts[i] = &tilesheet{tts.Image, tts.TileWidth, tts.TileHeight, tts.Firstgid}
 	}
 
 	levelTileset := createTileset(level, ts)


### PR DESCRIPTION
This branch adds isometric and staggered isometric map support, and the ability to define new mappings.

Mapping points to map coordinates is abstracted into two complementary functions MapToPosition and PositionToMap  functions, which can be defined according to the map orientation. A setupOrientation() function provides default mappings for orthogonal, isometric, and staggered. Hex mapping should just be a matter of defining its position functions. 

Both adventure and tilemap demos work without change using their existing assets.