### PR TITLE
Fix framebuffer scale issue for OSX retina

### DIFF
--- a/common/render_shaders.go
+++ b/common/render_shaders.go
@@ -158,8 +158,8 @@ func (s *basicShader) Pre() {
 		s.projectionMatrix[0] = 1 / (engo.GameWidth() / 2)
 		s.projectionMatrix[4] = 1 / (-engo.GameHeight() / 2)
 	} else {
-		s.projectionMatrix[0] = 1 / (engo.CanvasWidth() / 2)
-		s.projectionMatrix[4] = 1 / (-engo.CanvasHeight() / 2)
+		s.projectionMatrix[0] = 1 / (engo.CanvasWidth() / (2 * engo.CanvasScale()))
+		s.projectionMatrix[4] = 1 / (-engo.CanvasHeight() / (2 * engo.CanvasScale()))
 	}
 
 	if s.cameraEnabled {
@@ -478,8 +478,8 @@ func (l *legacyShader) Pre() {
 		l.projectionMatrix[0] = 1 / (engo.GameWidth() / 2)
 		l.projectionMatrix[4] = 1 / (-engo.GameHeight() / 2)
 	} else {
-		l.projectionMatrix[0] = 1 / (engo.CanvasWidth() / 2)
-		l.projectionMatrix[4] = 1 / (-engo.CanvasHeight() / 2)
+		l.projectionMatrix[0] = 1 / (engo.CanvasWidth() / (2 * engo.CanvasScale()))
+		l.projectionMatrix[4] = 1 / (-engo.CanvasHeight() / (2 * engo.CanvasScale()))
 	}
 
 	if l.cameraEnabled {
@@ -909,8 +909,8 @@ func (l *textShader) Pre() {
 		l.projectionMatrix[0] = 1 / (engo.GameWidth() / 2)
 		l.projectionMatrix[4] = 1 / (-engo.GameHeight() / 2)
 	} else {
-		l.projectionMatrix[0] = 1 / (engo.CanvasWidth() / 2)
-		l.projectionMatrix[4] = 1 / (-engo.CanvasHeight() / 2)
+		l.projectionMatrix[0] = 1 / (engo.CanvasWidth() / (2 * engo.CanvasScale()))
+		l.projectionMatrix[4] = 1 / (-engo.CanvasHeight() / (2 * engo.CanvasScale()))
 	}
 
 	if l.cameraEnabled {

--- a/engo_glfw.go
+++ b/engo_glfw.go
@@ -105,19 +105,19 @@ func CreateWindow(title string, width, height int, fullscreen bool, msaa int) {
 	width, height = window.GetSize()
 	windowWidth, windowHeight = float32(width), float32(height)
 
-	vp := Gl.GetViewport()
-	canvasWidth, canvasHeight = float32(vp[2]), float32(vp[3])
+	fw, fh := window.GetFramebufferSize()
+	canvasWidth, canvasHeight = float32(fw), float32(fh)
 
 	if windowWidth <= canvasWidth && windowHeight <= canvasHeight {
 		scale = canvasWidth / windowWidth
 	}
 
 	window.SetFramebufferSizeCallback(func(window *glfw.Window, w, h int) {
-		windowWidth, windowHeight = float32(w), float32(h)
 		Gl.Viewport(0, 0, w, h)
+		width, height = window.GetSize()
+		windowWidth, windowHeight = float32(width), float32(width)
 
-		vp := Gl.GetViewport()
-		canvasWidth, canvasHeight = float32(vp[2]), float32(vp[3])
+		canvasWidth, canvasHeight = float32(w), float32(h)
 
 		if windowWidth <= canvasWidth && windowHeight <= canvasHeight {
 			scale = canvasWidth / windowWidth
@@ -125,13 +125,13 @@ func CreateWindow(title string, width, height int, fullscreen bool, msaa int) {
 	})
 
 	window.SetCursorPosCallback(func(window *glfw.Window, x, y float64) {
-		Input.Mouse.X, Input.Mouse.Y = float32(x), float32(y)
+		Input.Mouse.X, Input.Mouse.Y = float32(x)*scale, float32(y)*scale
 		Input.Mouse.Action = Move
 	})
 
 	window.SetMouseButtonCallback(func(window *glfw.Window, b glfw.MouseButton, a glfw.Action, m glfw.ModifierKey) {
 		x, y := window.GetCursorPos()
-		Input.Mouse.X, Input.Mouse.Y = float32(x), float32(y)
+		Input.Mouse.X, Input.Mouse.Y = float32(x)*scale, float32(y)*scale
 
 		// this is only valid because we use an internal structure that is
 		// 100% compatible with glfw3.h
@@ -171,8 +171,8 @@ func CreateWindow(title string, width, height int, fullscreen bool, msaa int) {
 		windowHeight = float32(heightInt)
 
 		// TODO: verify these for retina displays & verify if needed here
-		vp := Gl.GetViewport()
-		canvasWidth, canvasHeight = float32(vp[2]), float32(vp[3])
+		fw, fh := window.GetFramebufferSize()
+		canvasWidth, canvasHeight = float32(fw), float32(fh)
 
 		if !opts.ScaleOnResize {
 			gameWidth, gameHeight = float32(widthInt), float32(heightInt)
@@ -292,6 +292,10 @@ func CanvasWidth() float32 {
 
 func CanvasHeight() float32 {
 	return canvasHeight
+}
+
+func CanvasScale() float32 {
+	return scale
 }
 
 // SetCursor sets the pointer of the mouse to the defined standard cursor

--- a/engo_js.go
+++ b/engo_js.go
@@ -161,6 +161,10 @@ func CanvasHeight() float32 {
 	return float32(flt)
 }
 
+func CanvasScale() float32 {
+	return CanvasWidth()/WindowWidth()
+}
+
 func toPx(n int) string {
 	return strconv.FormatInt(int64(n), 10) + "px"
 }

--- a/engo_mobile.go
+++ b/engo_mobile.go
@@ -69,6 +69,10 @@ func CanvasHeight() float32 {
 	return canvasHeight
 }
 
+func CanvasScale() float32 {
+	return CanvasWidth()/WindowWidth()
+}
+
 func DestroyWindow() { /* nothing to do here? */ }
 
 func runLoop(defaultScene Scene, headless bool) {


### PR DESCRIPTION
There were a few things wrong with the code for scaling window size vs canvas size; the canvas (frame buffer) size was getting conflated with window size in `SetFramebufferSizeCallback`, and some of the code dealing with mouse coords was missing the scale factor. The last change was to adjust the scale of the projection matrix in the shaders to match the adjusted mouse coords. I wasn't sure if there was a better way to do this, but adjusting these few cases in `render_shaders.go` works. 

Fixes #379 
Fixes #388 