### PR TITLE
All Common Components now have GetCommonComponent methods

### DIFF
--- a/common/addbyinterface_test.go
+++ b/common/addbyinterface_test.go
@@ -1,0 +1,35 @@
+// Here we are testing that add by interface allows all the various components to be added simply to the various systems.
+
+// Simply compiling should show all the bits are pointing in the right direction
+
+package common
+
+import (
+	"testing"
+)
+
+//Until ecs is updated, this allows us to give BasicEntity the Interface it Needs
+type SafeBasic struct {
+	*ecs.BasicEntity
+}
+
+func (sb *SafeBasic) GetBasicEntity() *BasicEntity {
+	return sb.BasicEntity
+}
+
+type alltoall struct {
+	*SafeBasic
+	*AnimationComponent
+	*AudioComponent
+	*SpaceComponent
+	*RenderComponent
+	*MouseComponent
+}
+
+func Test_Adds(t *testing.T) {
+
+	ob := alltoall{
+		SafeBasic: SafeBasic{ecs.NewBasic()},
+	}
+
+}

--- a/common/addbyinterface_test.go
+++ b/common/addbyinterface_test.go
@@ -5,31 +5,55 @@
 package common
 
 import (
+	"engo.io/ecs"
+	"engo.io/engo"
 	"testing"
 )
 
-//Until ecs is updated, this allows us to give BasicEntity the Interface it Needs
+//Until ecs is updated with GetBasicEntity(), this allows us to give BasicEntity the Interface it Needs
 type SafeBasic struct {
-	*ecs.BasicEntity
+	ecs.BasicEntity
 }
 
-func (sb *SafeBasic) GetBasicEntity() *BasicEntity {
-	return sb.BasicEntity
+func (sb *SafeBasic) GetBasicEntity() *ecs.BasicEntity {
+	return &sb.BasicEntity
 }
 
-type alltoall struct {
+type Collidable struct {
 	*SafeBasic
-	*AnimationComponent
-	*AudioComponent
 	*SpaceComponent
-	*RenderComponent
-	*MouseComponent
+	*CollisionComponent
 }
 
-func Test_Adds(t *testing.T) {
+func Test_Collision(t *testing.T) {
 
-	ob := alltoall{
-		SafeBasic: SafeBasic{ecs.NewBasic()},
+	ob1 := Collidable{
+		SafeBasic:      &SafeBasic{ecs.NewBasic()},
+		SpaceComponent: &SpaceComponent{Width: 50, Height: 50, Position: engo.Point{50, 50}},
+		CollisionComponent: &CollisionComponent{
+			Solid: true,
+			Main:  true,
+		},
+	}
+
+	ob2 := Collidable{
+		SafeBasic:      &SafeBasic{ecs.NewBasic()},
+		SpaceComponent: &SpaceComponent{Width: 50, Height: 50, Position: engo.Point{25, 25}},
+		CollisionComponent: &CollisionComponent{
+			Solid: true,
+			Main:  false,
+		},
+	}
+
+	cs := CollisionSystem{}
+
+	cs.AddByInterface(ob1)
+	cs.AddByInterface(ob2)
+
+	if len(cs.entities) < 2 {
+		t.Log("Collision system should have 2 entites, got %d", len(cs.entities))
+		t.Fail()
+
 	}
 
 }

--- a/common/animation.go
+++ b/common/animation.go
@@ -94,6 +94,11 @@ func (ac *AnimationComponent) NextFrame() {
 	}
 }
 
+// GetAnimationComponent provides container classes with interface for access to Component
+func (ac *AnimationComponent) GetAnimationComponent() *AnimationComponent {
+	return ac
+}
+
 // AnimationSystem tracks AnimationComponents, advancing their current animation.
 type AnimationSystem struct {
 	entities map[ecs.BasicEntity]animationEntity
@@ -110,6 +115,16 @@ func (a *AnimationSystem) Add(basic *ecs.BasicEntity, anim *AnimationComponent, 
 		a.entities = make(map[ecs.BasicEntity]animationEntity)
 	}
 	a.entities[*basic] = animationEntity{anim, render}
+}
+
+// AddByInterface is a Simpler outward facing equivilant of Add, as long as the object meets the interface it can be added safely. Each Component, should provide these methods, so that entities automatically fulfull the interface
+func (a *AnimationSystem) AddByInterface(ob interface {
+	GetBasicEntity() *ecs.BasicEntity
+	GetAnimationComponent() *AnimationComponent
+	GetRenderComponent() *RenderComponent
+}) {
+	a.Add(ob.GetBasicEntity(), ob.GetAnimationComponent(), ob.GetRenderComponent())
+
 }
 
 // Remove stops tracking the given entity.

--- a/common/audio.go
+++ b/common/audio.go
@@ -37,10 +37,21 @@ func (ac *AudioComponent) SetVolume(volume float64) {
 	ac.player.SetVolume(volume * MasterVolume)
 }
 
+func (ac *AudioComponent) GetAudioComponent() *AudioComponent {
+	return ac
+}
+
 type audioEntity struct {
 	*ecs.BasicEntity
 	*AudioComponent
 	*SpaceComponent
+}
+
+//interface for adding audio entities using AddByInterface
+type AudioInterface interface {
+	GetBasicEntity() *ecs.BasicEntity
+	GetAudioComponent() *AudioComponent
+	GetSpaceComponent() *SpaceComponent
 }
 
 // AudioSystem is a System that allows for sound effects and / or music
@@ -67,6 +78,11 @@ func AudioSystemPreload() {
 // where it's originated from)
 func (a *AudioSystem) Add(basic *ecs.BasicEntity, audio *AudioComponent, space *SpaceComponent) {
 	a.entities = append(a.entities, audioEntity{basic, audio, space})
+}
+
+// AddByInterface is afriendly outward face for Add As long as the entity has the required components, this a simpler way to add it.
+func (a *AudioSystem) AddByInterface(ob AudioInterface) {
+	a.Add(ob.GetBasicEntity(), ob.GetAudioComponent(), ob.GetSpaceComponent())
 }
 
 func (a *AudioSystem) Remove(basic ecs.BasicEntity) {

--- a/common/collision.go
+++ b/common/collision.go
@@ -15,6 +15,11 @@ type SpaceComponent struct {
 	Rotation float32 // angle in degrees for the rotation to apply clockwise
 }
 
+// GetSpaceComponent returns self, so that containers fullfill the interface, for ease of adding to systems by Interface
+func (sc *SpaceComponent) GetSpaceComponenet() *SpaceComponent {
+	return sc
+}
+
 // Center positions the space component according to its center instead of its
 // top-left point (this avoids doing the same math each time in your systems)
 func (sc *SpaceComponent) Center(p engo.Point) {
@@ -139,12 +144,22 @@ type collisionEntity struct {
 	*SpaceComponent
 }
 
+type Collisioner interface {
+	GetBasicEntity() *ecs.BasicEntity
+	GetCollisionComponent() *CollisionComponent
+	GetSpaceComponent() *SpaceComponent
+}
+
 type CollisionSystem struct {
 	entities []collisionEntity
 }
 
 func (c *CollisionSystem) Add(basic *ecs.BasicEntity, collision *CollisionComponent, space *SpaceComponent) {
 	c.entities = append(c.entities, collisionEntity{basic, collision, space})
+}
+
+func (c *CollisionSystem) AddByInterface(ob Collisioner) {
+	c.Add(ob.GetBasicEntity(), ob.GetCollisionComponent(), ob.GetSpaceComponent())
 }
 
 func (c *CollisionSystem) Remove(basic ecs.BasicEntity) {

--- a/common/collision.go
+++ b/common/collision.go
@@ -16,7 +16,7 @@ type SpaceComponent struct {
 }
 
 // GetSpaceComponent returns self, so that containers fullfill the interface, for ease of adding to systems by Interface
-func (sc *SpaceComponent) GetSpaceComponenet() *SpaceComponent {
+func (sc *SpaceComponent) GetSpaceComponent() *SpaceComponent {
 	return sc
 }
 
@@ -129,6 +129,10 @@ type CollisionComponent struct {
 	Solid, Main bool
 	Extra       engo.Point
 	Collides    bool // Collides is true if the component is colliding with something during this pass
+}
+
+func (cc *CollisionComponent) GetCollisionComponent() *CollisionComponent {
+	return cc
 }
 
 type CollisionMessage struct {

--- a/common/mouse.go
+++ b/common/mouse.go
@@ -92,11 +92,23 @@ type MouseComponent struct {
 	startedDragging bool
 }
 
+func (mc *MouseComponent) GetMouseComponent() *MouseComponent {
+	return mc
+}
+
 type mouseEntity struct {
 	*ecs.BasicEntity
 	*MouseComponent
 	*SpaceComponent
 	*RenderComponent
+}
+
+//Mouser is used by AddByInterface for adding objects to the system.
+type Mouser interface {
+	GetBasicEntity() *ecs.BasicEntity
+	GetMouseComponent() *MouseComponent
+	GetSpaceComponent() *SpaceComponent
+	GetRenderComponent() *RenderComponent
 }
 
 // MouseSystem listens for mouse events, and changes value for MouseComponent accordingly
@@ -138,6 +150,11 @@ func (m *MouseSystem) New(w *ecs.World) {
 // * BasicEntity is always required.
 func (m *MouseSystem) Add(basic *ecs.BasicEntity, mouse *MouseComponent, space *SpaceComponent, render *RenderComponent) {
 	m.entities = append(m.entities, mouseEntity{basic, mouse, space, render})
+}
+
+//AddByInterface allows simple adding of simple objects
+func (m *MouseSystem) AddByInterface(ob Mouser) {
+	m.Add(ob.GetBasicEntity(), ob.GetMouseComponent(), ob.GetSpaceComponent(), ob.GetRenderComponent())
 }
 
 func (m *MouseSystem) Remove(basic ecs.BasicEntity) {

--- a/common/render.go
+++ b/common/render.go
@@ -66,10 +66,22 @@ func (r *RenderComponent) SetZIndex(index float32) {
 	engo.Mailbox.Dispatch(&renderChangeMessage{})
 }
 
+// GetRenderComponent is for AddByInterface methods and can be accessed on it's containers to get this component
+func (r *RenderComponent) GetRenderComponent() *RenderComponent {
+	return r
+}
+
 type renderEntity struct {
 	*ecs.BasicEntity
 	*RenderComponent
 	*SpaceComponent
+}
+
+//Allows AddByInterface
+type RenderInterface interface {
+	GetBasicEntity() *ecs.BasicEntity
+	GetRenderComponent() *RenderComponent
+	GetSpaceComponent() *SpaceComponent
 }
 
 type renderEntityList []renderEntity
@@ -156,6 +168,11 @@ func (rs *RenderSystem) Add(basic *ecs.BasicEntity, render *RenderComponent, spa
 
 	rs.entities = append(rs.entities, renderEntity{basic, render, space})
 	rs.sortingNeeded = true
+}
+
+//AddByInterface adds the object using the GetComponent Methods defined, to make it simpler to add normal objects to the System
+func (rs *RenderSystem) AddByInterface(ob RenderInterface) {
+	rs.Add(ob.GetBasicEntity(), ob.GetRenderComponent(), ob.GetSpaceComponent())
 }
 
 func (rs *RenderSystem) Remove(basic ecs.BasicEntity) {


### PR DESCRIPTION
Each CommonComponent now has a GetCommonComponent method.

eg 
```
func (sc *SpaceComponent) GetSpaceComponent() *SpaceComponent{
    return sc
}
```

All common systems, with Add methods now also have an AddByInterface method, using the GetCommonComponent methods as required methods.  These are of course propogated to the container of the objects, so each entity, with a component automaticalle implements the required interface.

I have also created a Pull request in ecs to make sure GetBasicEntity is also available

At the user end, they can create the objects in the same way as before, but now they can add the object to the system using the AddByInteface()

eg
```
sys.AdByInterface(ob)
```

which is much simpler than 
```
sys.Add(ob.BasicEntity,ob.SpaceComponent,on.OtherComponent)
```

And doesn't require the user to remember the order.