### PR TITLE
Added Get__Component methods, and interfaces, and all the AddByInterf…

### DIFF
--- a/common/animation.go
+++ b/common/animation.go
@@ -112,6 +112,11 @@ func (a *AnimationSystem) Add(basic *ecs.BasicEntity, anim *AnimationComponent, 
 	a.entities[*basic] = animationEntity{anim, render}
 }
 
+// AddByInterface Allows an Entity to be added directly using the Animtionable interface. which every entity containing the BasicEntity,AnimationComponent,and RenderComponent anonymously, automatically satisfies.
+func (a *AnimationSystem) AddByInterface(o Animationable) {
+	a.Add(o.GetBasicEntity(), o.GetAnimationComponent(), o.GetRenderComponent())
+}
+
 // Remove stops tracking the given entity.
 func (a *AnimationSystem) Remove(basic ecs.BasicEntity) {
 	if a.entities != nil {

--- a/common/audio.go
+++ b/common/audio.go
@@ -69,6 +69,12 @@ func (a *AudioSystem) Add(basic *ecs.BasicEntity, audio *AudioComponent, space *
 	a.entities = append(a.entities, audioEntity{basic, audio, space})
 }
 
+// AddByInterface adds an entity to the system using the Audioable interface. This allows for entities to be added without specifying each component
+// If you do not wish to add a SpaceComponent, call Add, with the basic, then audio components, followed by nil
+func (a *AudioSystem) AddByInterface(o Audioable) {
+	a.Add(o.GetBasicEntity(), o.GetAudioComponent(), o.GetSpaceComponent())
+}
+
 func (a *AudioSystem) Remove(basic ecs.BasicEntity) {
 	delete := -1
 	for index, e := range a.entities {

--- a/common/audio_unsupported.go
+++ b/common/audio_unsupported.go
@@ -41,5 +41,7 @@ func (as *AudioSystem) New(*ecs.World) {
 }
 
 func (as *AudioSystem) Add(*ecs.BasicEntity, *AudioComponent, *SpaceComponent) {}
+func (as *AudioSystem) AddByInterface(o Audioable)                             {}
 func (as *AudioSystem) Remove(basic ecs.BasicEntity)                           {}
-func (as *AudioSystem) Update(dt float32)                                      {}
+
+func (as *AudioSystem) Update(dt float32) {}

--- a/common/collision.go
+++ b/common/collision.go
@@ -147,6 +147,11 @@ func (c *CollisionSystem) Add(basic *ecs.BasicEntity, collision *CollisionCompon
 	c.entities = append(c.entities, collisionEntity{basic, collision, space})
 }
 
+// AddByInterface Provides a simple way to add an entity to the system that satisfies Collisionable. Any entity containing, BasicEntity,CollisionComponent, and SpaceComponent anonymously, automatically does this.
+func (c *CollisionSystem) AddByInterface(o Collisionable) {
+	c.Add(o.GetBasicEntity(), o.GetCollisionComponent(), o.GetSpaceComponent())
+}
+
 func (c *CollisionSystem) Remove(basic ecs.BasicEntity) {
 	delete := -1
 	for index, e := range c.entities {

--- a/common/interfaces.go
+++ b/common/interfaces.go
@@ -1,0 +1,121 @@
+// interfaces.go is intended to provide a simple means of adding components to each system
+// Getters
+// These are added functions to each class to allow them to meet the interfaces we use with AddByInterface methods on each system
+// Faces
+// The interfaces that end in "Face" are all met by a specific component, which can be composed into an Entity
+// The word Get is used because, otherwise it would collide with the name of the object, when stored anonymously in a parent entity
+// Ables
+// The interfaces that end in "able" are those required by a specific system, and if an an object meets this interface it can be added to that system
+// Note: *able* is used not *er* because they don't really do thing anything
+// Note: The names have not been contracted for consistency, the interface is *Collisionable* not *Collidable*
+package common
+
+import "engo.io/ecs"
+
+// Getters
+
+// GetAnimationComponent Provides container classes ability to fulfil the interface and be accessed more simply by systems, eg in AddByInterface Methods
+func (c *AnimationComponent) GetAnimationComponent() *AnimationComponent {
+	return c
+}
+
+// GetMouseComponent Provides container classes ability to fulfil the interface and be accessed more simply by systems, eg in AddByInterface Methods
+func (c *MouseComponent) GetMouseComponent() *MouseComponent {
+	return c
+}
+
+// GetAudioComponent Provides container classes ability to fulfil the interface and be accessed more simply by systems, eg in AddByInterface Methods
+func (c *AudioComponent) GetAudioComponent() *AudioComponent {
+	return c
+}
+
+// GetRenderComponent Provides container classes ability to fulfil the interface and be accessed more simply by systems, eg in AddByInterface Methods
+func (c *RenderComponent) GetRenderComponent() *RenderComponent {
+	return c
+}
+
+// GetSpaceComponent Provides container classes ability to fulfil the interface and be accessed more simply by systems, eg in AddByInterface Methods
+func (c *SpaceComponent) GetSpaceComponent() *SpaceComponent {
+	return c
+}
+
+// GetCollisionComponent Provides container classes ability to fulfil the interface and be accessed more simply by systems, eg in AddByInterface Methods
+func (c *CollisionComponent) GetCollisionComponent() *CollisionComponent {
+	return c
+}
+
+// Faces
+
+// BasicFace is the means of accessing the ecs.BasicEntity class , it also has the ID method, to simplfy, finding an item within a system
+type BasicFace interface {
+	ID() uint64
+	GetBasicEntity() *ecs.BasicEntity
+}
+
+// AnimationFace allows typesafe Access to an Annonymous child AnimationComponent
+type AnimationFace interface {
+	GetAnimationComponent() *AnimationComponent
+}
+
+// MouseFace allows typesafe access to an Anonymous child MouseComponent
+type MouseFace interface {
+	GetMouseComponent() *MouseComponent
+}
+
+// AudioFace allows typesafe access to an anonymouse child AudioComponent
+type AudioFace interface {
+	GetAudioComponent() *AudioComponent
+}
+
+// RenderFace allows typesafe access to an anonymous RenderComponent
+type RenderFace interface {
+	GetRenderComponent() *RenderComponent
+}
+
+// SpaceFace allows typesafe access to an anonymous SpaceComponent
+type SpaceFace interface {
+	GetSpaceComponent() *SpaceComponent
+}
+
+// CollisionFace allows typesafe access to an anonymous CollisionComponent
+type CollisionFace interface {
+	GetCollisionComponent() *CollisionComponent
+}
+
+// Combined for systems
+
+// Animationable is the required interface for AnimationSystem.AddByInterface method
+type Animationable interface {
+	BasicFace
+	AnimationFace
+	RenderFace
+}
+
+// Mouseable is the required interface for the MouseSystem AddByInterface method
+type Mouseable interface {
+	BasicFace
+	MouseFace
+	SpaceFace
+	RenderFace
+}
+
+// Audioable is the required interface for the AudioSystem.AddByInterface method
+type Audioable interface {
+	BasicFace
+	AudioFace
+	SpaceFace
+}
+
+// Renderable is the required interface for the RenderSystem.AddByInterface method
+type Renderable interface {
+	BasicFace
+	RenderFace
+	SpaceFace
+}
+
+// Collisionable is the required interface for the CollisionSystem.AddByInterface method
+type Collisionable interface {
+	BasicFace
+	CollisionFace
+	SpaceFace
+}

--- a/common/interfaces_test.go
+++ b/common/interfaces_test.go
@@ -1,0 +1,106 @@
+package common
+
+import (
+	"testing"
+
+	"engo.io/ecs"
+)
+
+// SafeBasic is to provide a BasicEntity until ecs is updated to provide the GetBasicEntity method
+type SafeBasic struct {
+	ecs.BasicEntity
+}
+
+//Satisfy BasicFace interface
+func (sb *SafeBasic) GetBasicEntity() *ecs.BasicEntity {
+	return &sb.BasicEntity
+}
+
+func NewSafeBasic() SafeBasic {
+	return SafeBasic{
+		BasicEntity: ecs.NewBasic(),
+	}
+}
+
+type EveryComp struct {
+	SafeBasic
+	AnimationComponent
+	MouseComponent
+	RenderComponent
+	SpaceComponent
+	CollisionComponent
+	AudioComponent
+}
+
+// Test_Every Creates an Everything component and tries to add and then remove it from each system to each system using AddByInterface.
+// I can't test adding things that don't work as the code won't compile
+func Test_Every(t *testing.T) {
+	e := &EveryComp{
+		SafeBasic: NewSafeBasic(),
+	}
+
+	//Wanted to use a loop to do this, but each "AddByInterface" is actually different nmind
+
+	//AnimationSystem
+	as := &AnimationSystem{}
+	as.AddByInterface(e)
+	if len(as.entities) != 1 {
+		t.Logf("AnimationSystem should have 1 entity, got %d", len(as.entities))
+		t.Fail()
+	}
+	as.Remove(*e.GetBasicEntity())
+	if len(as.entities) > 0 {
+		t.Logf("AnimationSystem should now be empty")
+		t.Fail()
+	}
+
+	//MouseSystem
+	ms := &MouseSystem{}
+	ms.AddByInterface(e)
+	if len(ms.entities) != 1 {
+		t.Logf("MouseSystem should have 1 entity, got %d", len(ms.entities))
+		t.Fail()
+	}
+	ms.Remove(*e.GetBasicEntity())
+	if len(ms.entities) > 0 {
+		t.Logf("MouseSystem should now be empty")
+		t.Fail()
+	}
+	//AudioSystem
+	aus := &AudioSystem{}
+	aus.AddByInterface(e)
+	if len(aus.entities) != 1 {
+		t.Logf("AudioSystem should have 1 entity, got %d", len(aus.entities))
+		t.Fail()
+	}
+	aus.Remove(*e.GetBasicEntity())
+	if len(aus.entities) > 0 {
+		t.Logf("AudioSystem should now be empty")
+		t.Fail()
+	}
+	//RenderSystem
+	rs := &RenderSystem{}
+	rs.AddByInterface(e)
+	if len(rs.entities) != 1 {
+		t.Logf("RenderSystem should have 1 entity, got %d", len(rs.entities))
+		t.Fail()
+	}
+	rs.Remove(*e.GetBasicEntity())
+	if len(rs.entities) > 0 {
+		t.Logf("RenderSystem should now be empty")
+		t.Fail()
+	}
+	//CollisionSystem
+	cs := &CollisionSystem{}
+	cs.AddByInterface(e)
+	if len(cs.entities) != 1 {
+		t.Logf("CollisionSystem should have 1 entity, got %d", len(cs.entities))
+		t.Fail()
+	}
+	cs.Remove(*e.GetBasicEntity())
+	if len(cs.entities) > 0 {
+		t.Logf("CollisionSystem should now be empty")
+		t.Fail()
+	}
+
+}

--- a/common/mouse.go
+++ b/common/mouse.go
@@ -140,6 +140,11 @@ func (m *MouseSystem) Add(basic *ecs.BasicEntity, mouse *MouseComponent, space *
 	m.entities = append(m.entities, mouseEntity{basic, mouse, space, render})
 }
 
+// AddByInterface adds the Entity to the system as long as it satisfies, Mouseable.  Any Entity containing a BasicEntity,MouseComponent, and RenderComponent, automatically does this.
+func (m *MouseSystem) AddByInterface(o Mouseable) {
+	m.Add(o.GetBasicEntity(), o.GetMouseComponent(), o.GetSpaceComponent(), o.GetRenderComponent())
+}
+
 func (m *MouseSystem) Remove(basic ecs.BasicEntity) {
 	var delete int = -1
 	for index, entity := range m.entities {

--- a/common/render.go
+++ b/common/render.go
@@ -158,6 +158,11 @@ func (rs *RenderSystem) Add(basic *ecs.BasicEntity, render *RenderComponent, spa
 	rs.sortingNeeded = true
 }
 
+// AddByInterface adds any Renderable to the render system. Any Entity containing a BasicEntity,RenderComponent, and SpaceComponent anonymously does this automatically
+func (rs *RenderSystem) AddByInterface(o Renderable) {
+	rs.Add(o.GetBasicEntity(), o.GetRenderComponent(), o.GetSpaceComponent())
+}
+
 func (rs *RenderSystem) Remove(basic ecs.BasicEntity) {
 	var delete int = -1
 	for index, entity := range rs.entities {


### PR DESCRIPTION
…ace methods

This is the updated pull request, I hope I have done this right, I'm relatively new to using Git.

This Pull request adds a File full of useful interfaces.  called interfaces.go, and adds the Get__Component Methods to each Component Type.
The methods are still called Get__ as I removeing the Get, made a name collision, within the parent objects.  

The "AddByInterface" methods which allow Systems to add an Entity as one parameter long as it has the correct components are all directly after the Add method which they call.

interface_test.go has also been added, and this tries all of the AddByInterface methods and checks the objects are added, and removable.

For this update to be effective, it will also be helpful to pull the request on Engo.ecs to give ecs.BasicEntity a GetBasicEntity Method, then all of this will work together.