### PR TITLE
New method SpaceComponent.Center()

### DIFF
--- a/common/collision.go
+++ b/common/collision.go
@@ -25,6 +25,15 @@ func (sc *SpaceComponent) Center(p engo.Point) {
 	sc.Position.Y = p.Y - yDelta
 }
 
+// GetCenter gets the center position of the space component instead of its
+// top-left point (this avoids doing the same math each time in your systems)
+func (sc *SpaceComponent) GetCenter() engo.Point {
+	xDelta := sc.Width / 2
+	yDelta := sc.Height / 2
+	p := sc.Position
+	return engo.Point{p.X + xDelta, p.Y + yDelta}
+}
+
 // AABB returns the minimum and maximum point for the given SpaceComponent. It hereby takes into account the
 // rotation of the Component - it may very well be that the Minimum as given by engo.AABB, is smaller than the Position
 // of the object (i.e. when rotated).

--- a/common/collision_test.go
+++ b/common/collision_test.go
@@ -60,3 +60,25 @@ func TestSpaceComponent_Corners(t *testing.T) {
 		assert.True(t, exp2[i].Equal(act2[i]), fmt.Sprintf("corner %d did not match for rotation %f (got %v expected %v)", i, space2.Rotation, act2[i], exp2[i]))
 	}
 }
+
+func TestSpaceComponent_Center(t *testing.T) {
+	components := []SpaceComponent{
+		SpaceComponent{Width: 0, Height: 0},
+		SpaceComponent{Width: 100, Height: 100},
+		SpaceComponent{Width: 100, Height: 200},
+	}
+	points := []engo.Point{
+		engo.Point{10, 10},
+		engo.Point{50, 50},
+		engo.Point{10, 50},
+		engo.Point{99, 99},
+	}
+
+	for _, sc := range components {
+		for _, p := range points {
+			sc.Center(p)
+			c := sc.GetCenter()
+			assert.True(t, c.Equal(p), fmt.Sprintf("center %v should be equal to point %v", c, p))
+		}
+	}
+}


### PR DESCRIPTION
This method gets the center position of the space component instead of its top-left point.
The go idiomatic way would be to rename Center(p) to SetCenter(p) and GetCenter() to Center(). But since that change would break backwards-compability I went for GetCenter() as the new method name.

If you would like the methods to be renamed to SetCenter(p) and Center() I can change the commit accordingly. As a first time contributor I think it is not up to me to decide whether or not a change like this should break backwards-compability. :)