### PR TITLE
Fixed Mouse Action being overwritten

### DIFF
--- a/engo_glfw.go
+++ b/engo_glfw.go
@@ -126,7 +126,9 @@ func CreateWindow(title string, width, height int, fullscreen bool, msaa int) {
 
 	window.SetCursorPosCallback(func(window *glfw.Window, x, y float64) {
 		Input.Mouse.X, Input.Mouse.Y = float32(x)*scale, float32(y)*scale
-		Input.Mouse.Action = Move
+		if Input.Mouse.Action != Release && Input.Mouse.Action != Press {
+			Input.Mouse.Action = Move
+		}
 	})
 
 	window.SetMouseButtonCallback(func(window *glfw.Window, b glfw.MouseButton, a glfw.Action, m glfw.ModifierKey) {


### PR DESCRIPTION
On some systems a right click also triggers a CursorPos callback, and left click with rapid mouse movement also triggers a CursorPos Callback. Since Release and Press actions are usually prefered to be reported over the Move action, an if statement ensures that the mouse button clicks are reported over mouse movement. Edit: This was written in order to solve Issue#417 