### PR TITLE
flipped the signs on collision.go initial bounds for AABB()

### DIFF
--- a/common/collision.go
+++ b/common/collision.go
@@ -52,10 +52,10 @@ func (sc SpaceComponent) AABB() engo.AABB {
 	corners := sc.Corners()
 
 	var (
-		xMin float32 = -math.MaxFloat32
-		xMax float32 = math.MaxFloat32
-		yMin float32 = -math.MaxFloat32
-		yMax float32 = math.MaxFloat32
+		xMin float32 = math.MaxFloat32
+		xMax float32 = -math.MaxFloat32
+		yMin float32 = math.MaxFloat32
+		yMax float32 = -math.MaxFloat32
 	)
 
 	for i := 0; i < 4; i++ {


### PR DESCRIPTION
flipped the signs on collision.go initial bounds for AABB(), so that AABB() returns the actual max bounds of the Space Component, rather than the max bounds of +/- MaxFloat32
fixes #441