### PR TITLE
close game for gomobile

### DIFF
--- a/engo_mobile.go
+++ b/engo_mobile.go
@@ -108,6 +108,7 @@ func runLoop(defaultScene Scene, headless bool) {
 					a.Send(paint.Event{})
 				case lifecycle.CrossOff:
 					closeEvent()
+					Gl = nil
 				}
 
 			case size.Event:
@@ -126,9 +127,6 @@ func runLoop(defaultScene Scene, headless bool) {
 				}
 
 				RunIteration()
-				if closeGame {
-					break
-				}
 
 				fps.Draw(sz)
 


### PR DESCRIPTION
Needed to clean up Gl context when the game closes. Otherwise the game just freezes and crashes on next restart unless it's force closed.
We also want to use the device's lifecycle and cross-off when closing rather than use a break to get out of the main loop.

#447 