### PR TITLE
Android and gopherjs resize drawing fix

### DIFF
--- a/common/render_shaders.go
+++ b/common/render_shaders.go
@@ -228,8 +228,8 @@ func (s *basicShader) Draw(ren *RenderComponent, space *SpaceComponent) {
 		s.modelMatrix[4] = ren.Scale.Y
 	}
 
-	s.modelMatrix[6] = space.Position.X
-	s.modelMatrix[7] = space.Position.Y
+	s.modelMatrix[6] = space.Position.X + (engo.ResizeXOffset / 2.0)
+	s.modelMatrix[7] = space.Position.Y + (engo.ResizeYOffset / 2.0)
 
 	engo.Gl.UniformMatrix3fv(s.matrixModel, false, s.modelMatrix)
 
@@ -705,8 +705,8 @@ func (l *legacyShader) Draw(ren *RenderComponent, space *SpaceComponent) {
 		l.modelMatrix[4] = ren.Scale.Y
 	}
 
-	l.modelMatrix[6] = space.Position.X
-	l.modelMatrix[7] = space.Position.Y
+	l.modelMatrix[6] = space.Position.X + (engo.ResizeXOffset / 2.0)
+	l.modelMatrix[7] = space.Position.Y + (engo.ResizeYOffset / 2.0)
 
 	engo.Gl.UniformMatrix3fv(l.matrixModel, false, l.modelMatrix)
 
@@ -1070,8 +1070,8 @@ func (l *textShader) Draw(ren *RenderComponent, space *SpaceComponent) {
 		l.modelMatrix[4] = ren.Scale.Y
 	}
 
-	l.modelMatrix[6] = space.Position.X
-	l.modelMatrix[7] = space.Position.Y
+	l.modelMatrix[6] = space.Position.X + (engo.ResizeXOffset / 2.0)
+	l.modelMatrix[7] = space.Position.Y + (engo.ResizeYOffset / 2.0)
 
 	engo.Gl.UniformMatrix3fv(l.matrixModel, false, l.modelMatrix)
 	engo.Gl.DrawElements(engo.Gl.TRIANGLES, 6*len(txt.Text), engo.Gl.UNSIGNED_SHORT, 0)

--- a/engo_glfw.go
+++ b/engo_glfw.go
@@ -32,6 +32,9 @@ var (
 	headlessHeight            = 800
 	canvasWidth, canvasHeight float32
 	scale                     = float32(1)
+
+	ResizeXOffset = float32(0)
+	ResizeYOffset = float32(0)
 )
 
 // fatalErr calls log.Fatal with the given error if it is non-nil.
@@ -114,10 +117,14 @@ func CreateWindow(title string, width, height int, fullscreen bool, msaa int) {
 
 	window.SetFramebufferSizeCallback(func(window *glfw.Window, w, h int) {
 		Gl.Viewport(0, 0, w, h)
+		oldCanvasW, oldCanvasH := canvasWidth, canvasHeight
 		width, height = window.GetSize()
 		windowWidth, windowHeight = float32(width), float32(width)
 
 		canvasWidth, canvasHeight = float32(w), float32(h)
+
+		ResizeXOffset += oldCanvasW - canvasWidth
+		ResizeYOffset += oldCanvasH - canvasHeight
 
 		if windowWidth <= canvasWidth && windowHeight <= canvasHeight {
 			scale = canvasWidth / windowWidth

--- a/engo_js.go
+++ b/engo_js.go
@@ -23,6 +23,9 @@ var (
 	Gl *gl.Context
 
 	devicePixelRatio float64
+
+	ResizeXOffset = float32(0)
+	ResizeYOffset = float32(0)
 )
 
 func init() {
@@ -75,6 +78,9 @@ func CreateWindow(title string, width, height int, fullscreen bool, msaa int) {
 	gameHeight = float32(height)
 	windowWidth = WindowWidth()
 	windowHeight = WindowHeight()
+
+	ResizeXOffset = gameWidth - CanvasWidth()
+	ResizeYOffset = gameHeight - CanvasHeight()
 
 	w := dom.GetWindow()
 	w.AddEventListener("keypress", false, func(ev dom.Event) {
@@ -162,7 +168,7 @@ func CanvasHeight() float32 {
 }
 
 func CanvasScale() float32 {
-	return CanvasWidth()/WindowWidth()
+	return 1
 }
 
 func toPx(n int) string {

--- a/engo_mobile.go
+++ b/engo_mobile.go
@@ -122,7 +122,7 @@ func runLoop(defaultScene Scene, headless bool) {
 				canvasHeight = float32(sz.HeightPx)
 				Gl.Viewport(0, 0, sz.WidthPx, sz.HeightPx)
 				ResizeXOffset = (gameWidth - canvasWidth)
-				+ResizeYOffset = (gameHeight - canvasHeight)
+				ResizeYOffset = (gameHeight - canvasHeight)
 			case paint.Event:
 				if e.External {
 					// As we are actively painting as fast as

--- a/engo_mobile.go
+++ b/engo_mobile.go
@@ -108,6 +108,7 @@ func runLoop(defaultScene Scene, headless bool) {
 					a.Send(paint.Event{})
 				case lifecycle.CrossOff:
 					closeEvent()
+					Gl = nil
 				}
 
 			case size.Event:
@@ -126,9 +127,6 @@ func runLoop(defaultScene Scene, headless bool) {
 				}
 
 				RunIteration()
-				if closeGame {
-					break
-				}
 
 				fps.Draw(sz)
 

--- a/engo_mobile.go
+++ b/engo_mobile.go
@@ -29,6 +29,9 @@ var (
 	canvasWidth, canvasHeight float32
 
 	msaaPreference int
+
+	ResizeXOffset = float32(0)
+	ResizeYOffset = float32(0)
 )
 
 // CreateWindow creates a window with the specified parameters
@@ -70,7 +73,7 @@ func CanvasHeight() float32 {
 }
 
 func CanvasScale() float32 {
-	return CanvasWidth()/WindowWidth()
+	return CanvasWidth() / WindowWidth()
 }
 
 func DestroyWindow() { /* nothing to do here? */ }
@@ -118,6 +121,8 @@ func runLoop(defaultScene Scene, headless bool) {
 				canvasWidth = float32(sz.WidthPx)
 				canvasHeight = float32(sz.HeightPx)
 				Gl.Viewport(0, 0, sz.WidthPx, sz.HeightPx)
+				ResizeXOffset = (gameWidth - canvasWidth)
+				+ResizeYOffset = (gameHeight - canvasHeight)
 			case paint.Event:
 				if e.External {
 					// As we are actively painting as fast as


### PR DESCRIPTION
Issues #449 and #428 

The problem was actually due to window resizing. You could make it show up on glfw by changing the window size manually while running. When a window resizes, the space components position is still in the original coordinates, so the entities are being drawn to the screen in the old space instead of new. To fix this, I added resize offset variables that keep track of how much the window size changes and it adjusts the position in the shader matrix when drawing to the screen. The issue was compounded in gopherjs due to the canvas scale not being one, which created even more of an offset.