### PR TITLE
common: add whitespace to package comments for better godoc

### DIFF
--- a/common/interfaces.go
+++ b/common/interfaces.go
@@ -1,12 +1,20 @@
 // interfaces.go is intended to provide a simple means of adding components to each system
+//
 // Getters
+//
 // These are added functions to each class to allow them to meet the interfaces we use with AddByInterface methods on each system
+//
 // Faces
+//
 // The interfaces that end in "Face" are all met by a specific component, which can be composed into an Entity
 // The word Get is used because, otherwise it would collide with the name of the object, when stored anonymously in a parent entity
+//
 // Ables
+//
 // The interfaces that end in "able" are those required by a specific system, and if an an object meets this interface it can be added to that system
+//
 // Note: *able* is used not *er* because they don't really do thing anything
+//
 // Note: The names have not been contracted for consistency, the interface is *Collisionable* not *Collidable*
 package common
 


### PR DESCRIPTION
I added whitespace to the package comment in common/interfaces.go which fixed ugly godoc html rendering. It now makes Getters, Faces, etc. appear as nice headings in the godoc Overview section. 

The line 1 `interfaces.go is intended...` looks a bit out of place now in the documentation and should likely be moved around. But, I'm still learning engo so I probably shouldn't be the one to decide that. 