### PR TITLE
add documentation to MinZoom and MaxZoom in common/camera.go

### DIFF
--- a/common/camera.go
+++ b/common/camera.go
@@ -20,7 +20,13 @@ const (
 )
 
 var (
+	// MinZoom is the closest the camera position can be relative to the
+	// rendered surface. Smaller numbers of MinZoom allows greater
+	// perceived zooming "in".
 	MinZoom float32 = 0.25
+	// MaxZoom is the farthest the camera position can be relative to the
+	// rendered surface. Larger numbers of MaxZoom allows greater
+	// perceived zooming "out".
 	MaxZoom float32 = 3
 
 	CameraBounds engo.AABB


### PR DESCRIPTION
I spent several minutes tweaking MinZoom thinking it would let me zoom out farther, and lo and behold, it's the opposite! Added some documentation so future people won't have the same issue and can realize that you actually increase MaxZoom in order to zoom "out". 