### PR TITLE
Add "NotResizable" RunOpts option

### DIFF
--- a/engo.go
+++ b/engo.go
@@ -57,6 +57,9 @@ type RunOptions struct {
 	// VSync indicates whether or not OpenGL should wait for the monitor to swp the buffers
 	VSync bool
 
+	// Resizable indicates whether or not the Window should be resizable.  Defaults to `true`.
+	NotResizable bool
+
 	// ScaleOnResize indicates whether or not engo should make things larger/smaller whenever the screen resizes
 	ScaleOnResize bool
 

--- a/engo_glfw.go
+++ b/engo_glfw.go
@@ -87,6 +87,9 @@ func CreateWindow(title string, width, height int, fullscreen bool, msaa int) {
 	if opts.HeadlessMode {
 		glfw.WindowHint(glfw.Visible, glfw.False)
 	}
+	if opts.NotResizable {
+		glfw.WindowHint(glfw.Resizable, glfw.False)
+	}
 
 	glfw.WindowHint(glfw.ContextVersionMajor, 2)
 	glfw.WindowHint(glfw.ContextVersionMinor, 1)


### PR DESCRIPTION
This adds a `NotResizable` option that hints to `GLFW` that the window
should not be resizable if specified true.  `GLFW` defaults resizable
to true, so `RunOpts` does as well.

With `NotResizable: true` specified:
![image](https://user-images.githubusercontent.com/1476969/29000646-5f25b7b2-7a26-11e7-8341-020c96e890c8.png)
