### PR TITLE
Cursor visibility

### DIFF
--- a/engo_glfw.go
+++ b/engo_glfw.go
@@ -340,6 +340,16 @@ func SetVSync(enabled bool) {
 	}
 }
 
+//SetCursorVisibility sets the visibility of the cursor.
+//If true the cursor is visible, if false the cursor is not.
+func SetCursorVisibility(visible bool) {
+	if visible {
+		glfw.GetCurrentContext().SetInputMode(glfw.CursorMode, glfw.CursorNormal)
+	} else {
+		glfw.GetCurrentContext().SetInputMode(glfw.CursorMode, glfw.CursorHidden)
+	}
+}
+
 func init() {
 	runtime.LockOSThread()
 

--- a/engo_js.go
+++ b/engo_js.go
@@ -305,3 +305,13 @@ func SetCursor(c Cursor) {
 		document.Body().Style().Set("cursor", "hand")
 	}
 }
+
+//SetCursorVisibility sets the visibility of the cursor.
+//If true the cursor is visible, if false the cursor is not.
+func SetCursorVisibility(visible bool) {
+	if visible {
+		document.Body().Style().Set("cursor", "default")
+	} else {
+		document.Body().Style().Set("cursor", "none")
+	}
+}

--- a/engo_mobile.go
+++ b/engo_mobile.go
@@ -184,6 +184,11 @@ func SetCursor(Cursor) {
 	notImplemented("SetCursor")
 }
 
+//SetCursorVisibility sets the visibility of the cursor.
+//If true the cursor is visible, if false the cursor is not.
+//Does nothing in mobile since there's no visible cursor to begin with
+func SetCursorVisibility(visible bool) {}
+
 // SetTitle has no effect on mobile
 func SetTitle(title string) {}
 


### PR DESCRIPTION
Added a func SetCursorVisibility that sets the cursor visibility based on the passed boolean. Can be used to set the cursor visibility on the fly. Was tested using the mouse demo, instead of changing to a hand I had it set the visibility.

#465 