### PR TITLE
Reverse android bindings

### DIFF
--- a/assets.go
+++ b/assets.go
@@ -79,6 +79,15 @@ func (formats *Formats) Load(urls ...string) error {
 	return nil
 }
 
+// LoadBinData loads a resource when you already have the reader for it.
+func (formats *Formats) LoadReaderData(url string, f io.Reader) error {
+	ext := filepath.Ext(url)
+	if loader, ok := Files.formats[ext]; ok {
+		return loader.Load(url, f)
+	}
+	return fmt.Errorf("no `FileLoader` associated with this extension: %q in url %q", ext, url)
+}
+
 // Unload releases the given resource from memory.
 func (formats *Formats) Unload(url string) error {
 	ext := filepath.Ext(url)

--- a/engo.go
+++ b/engo.go
@@ -96,6 +96,9 @@ type RunOptions struct {
 	// mobile (Android/iOS), because they **require** all assets to be within the `assets` directory. You may however
 	// use any subfolder-structure within that `assets` directory.
 	AssetsRoot string
+
+	// MobileWidth and MobileHeight are the width and height given from the Android/iOS OpenGL Surface used for Gomobile bind
+	MobileWidth, MobileHeight int
 }
 
 // Run is called to create a window, initialize everything, and start the main loop. Once this function returns,

--- a/engo_mobile.go
+++ b/engo_mobile.go
@@ -1,4 +1,4 @@
-//+build android
+//+build android !mobilebind
 
 package engo
 

--- a/engo_mobile.go
+++ b/engo_mobile.go
@@ -1,4 +1,4 @@
-//+build android !mobilebind
+//+build android,!mobilebind
 
 package engo
 

--- a/engo_mobile_bind.go
+++ b/engo_mobile_bind.go
@@ -1,0 +1,181 @@
+//+build mobilebind
+
+package engo
+
+import (
+	"errors"
+	"io"
+	"runtime"
+	"time"
+
+	"engo.io/gl"
+	mgl "golang.org/x/mobile/gl"
+)
+
+var (
+	// Gl is the current OpenGL context
+	Gl     *gl.Context
+	worker mgl.Worker
+
+	canvasWidth, canvasHeight float32
+
+	msaaPreference int
+
+	ResizeXOffset = float32(0)
+	ResizeYOffset = float32(0)
+
+	Backend string = "Mobile"
+
+	drawEvent  = make(chan struct{})
+	drawDone   = make(chan struct{})
+	initalized = false
+)
+
+// CreateWindow creates a window with the specified parameters
+func CreateWindow(title string, width, height int, fullscreen bool, msaa int) {
+	gameWidth = float32(width)
+	gameHeight = float32(height)
+	msaaPreference = msaa
+}
+
+// WindowSize returns the width and height of the current window
+func WindowSize() (w, h int) {
+	return int(windowWidth), int(windowHeight)
+}
+
+// CursorPos returns the current cursor position
+func CursorPos() (x, y float32) {
+	notImplemented("CursorPos")
+	return 0, 0
+}
+
+// WindowWidth returns the current window width
+func WindowWidth() float32 {
+	return windowWidth
+}
+
+// WindowHeight returns the current window height
+func WindowHeight() float32 {
+	return windowHeight
+}
+
+// CanvasWidth returns the current canvas width
+func CanvasWidth() float32 {
+	return canvasWidth
+}
+
+// CanvasHeight returns the current canvas height
+func CanvasHeight() float32 {
+	return canvasHeight
+}
+
+func CanvasScale() float32 {
+	return CanvasWidth() / WindowWidth()
+}
+
+func DestroyWindow() { /* nothing to do here? */ }
+
+func runLoop(defaultScene Scene, headless bool) {
+	go func() {
+		for {
+			mobileDraw(defaultScene)
+		}
+	}()
+}
+
+// RunPreparation is called only once, and is called automatically when calling Open
+// It is only here for benchmarking in combination with OpenHeadlessNoRun
+func RunPreparation(defaultScene Scene) {
+	windowWidth = float32(opts.MobileWidth)
+	canvasWidth = float32(opts.MobileWidth)
+	windowHeight = float32(opts.MobileHeight)
+	canvasHeight = float32(opts.MobileHeight)
+	ResizeXOffset = gameWidth - canvasWidth
+	ResizeYOffset = gameHeight - canvasHeight
+
+	Gl.Viewport(0, 0, opts.MobileWidth, opts.MobileHeight)
+
+	Time = NewClock()
+	SetScene(defaultScene, false)
+}
+
+// RunIteration runs ever time android calls to update the screen
+func RunIteration() {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	select {
+	case drawEvent <- struct{}{}:
+		for {
+			select {
+			case <-worker.WorkAvailable():
+				worker.DoWork()
+			case <-drawDone:
+				return
+			}
+		}
+	case <-time.After(500 * time.Millisecond):
+		return
+	}
+}
+
+// SetCursor changes the cursor - not yet implemented
+func SetCursor(Cursor) {
+	notImplemented("SetCursor")
+}
+
+//SetCursorVisibility sets the visibility of the cursor.
+//If true the cursor is visible, if false the cursor is not.
+//Does nothing in mobile since there's no visible cursor to begin with
+func SetCursorVisibility(visible bool) {}
+
+// SetTitle has no effect on mobile
+func SetTitle(title string) {}
+
+// openFile is the mobile-specific way of opening a file
+func openFile(url string) (io.ReadCloser, error) {
+	return nil, errors.New("binding does not open files this way. utilize go-bindata instead")
+}
+
+// mobileDraw runs once per frame. RunIteration for most other backends
+func mobileDraw(defaultScene Scene) {
+	if !initalized {
+		var ctx mgl.Context
+		ctx, worker = mgl.NewContext()
+		Gl = gl.NewContext(ctx)
+	}
+	<-drawEvent
+	defer func() {
+		drawDone <- struct{}{}
+	}()
+
+	if !initalized {
+		RunPreparation(defaultScene)
+		initalized = true
+	}
+
+	Time.Tick()
+
+	if !opts.HeadlessMode {
+		Input.update()
+	}
+
+	Input.Mouse.Action = Neutral
+
+	// Then update the world and all Systems
+	currentWorld.Update(Time.Delta())
+}
+
+//TouchEvent handles the touch events sent from Android and puts them in the InputManager
+func TouchEvent(x, y, action int) {
+	Input.Mouse.X = float32(x)
+	Input.Mouse.Y = float32(y)
+	switch action {
+	case 0:
+		Input.Mouse.Action = Press
+	case 1:
+		Input.Mouse.Action = Release
+	case 2:
+		Input.Mouse.Action = Move
+	}
+}

--- a/engo_mobile_bind.go
+++ b/engo_mobile_bind.go
@@ -99,7 +99,7 @@ func RunPreparation(defaultScene Scene) {
 	SetScene(defaultScene, false)
 }
 
-// RunIteration runs ever time android calls to update the screen
+// RunIteration runs every time android calls to update the screen
 func RunIteration() {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
@@ -111,10 +111,12 @@ func RunIteration() {
 			case <-worker.WorkAvailable():
 				worker.DoWork()
 			case <-drawDone:
+				Input.Mouse.Action = Neutral
 				return
 			}
 		}
 	case <-time.After(500 * time.Millisecond):
+		Input.Mouse.Action = Neutral
 		return
 	}
 }
@@ -137,7 +139,7 @@ func openFile(url string) (io.ReadCloser, error) {
 	return nil, errors.New("binding does not open files this way. utilize go-bindata instead")
 }
 
-// mobileDraw runs once per frame. RunIteration for most other backends
+// mobileDraw runs once per frame. RunIteration for the other backends
 func mobileDraw(defaultScene Scene) {
 	if !initalized {
 		var ctx mgl.Context
@@ -160,8 +162,6 @@ func mobileDraw(defaultScene Scene) {
 		Input.update()
 	}
 
-	Input.Mouse.Action = Neutral
-
 	// Then update the world and all Systems
 	currentWorld.Update(Time.Delta())
 }
@@ -178,4 +178,11 @@ func TouchEvent(x, y, action int) {
 	case 2:
 		Input.Mouse.Action = Move
 	}
+}
+
+//MobileStop handles when the game is closed
+func MobileStop() {
+	closeEvent()
+	Gl = nil
+	worker = nil
 }


### PR DESCRIPTION
Allows you to build an android (and possibly ios but don't have access to a Mac) library that uses Engo as part of a GlSurfaceView in Android. In currently working on a tutorial for it's use on github.com/Noofbiz/mousetests. I'll update on here when the full tutorial is done. Basically you can create a library that's a replica of the main function except instead use Start(int, int) instead of main. Then create an android glue library within the project that gets called from Java. Then you can build the library package using gomobile bind -tags=mobilebind
This will generate the  . aar file that you add to your Java code for Android. I'll try to get the full tutorial up sometime this evening, but you guys can check out the code now and let me know if you have any comments or suggestions. 