### PR TITLE
common: parse gid from tmx objects

### DIFF
--- a/common/tmx_level.go
+++ b/common/tmx_level.go
@@ -2,19 +2,19 @@ package common
 
 import (
 	"bytes"
-	"compress/zlib"
 	"compress/gzip"
+	"compress/zlib"
 	"encoding/base64"
-	"encoding/csv"
 	"encoding/binary"
+	"encoding/csv"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"path"
 	"sort"
 	"strconv"
 	"strings"
-	"errors"
 
 	"engo.io/engo"
 )
@@ -127,7 +127,7 @@ func (d *TMXData) decodeCSV() ([]uint32, error) {
 }
 
 // Decode takes the encoded data from a tmx map file and
-// unpacks it an arrary of uint32 guids 
+// unpacks it an arrary of uint32 guids
 func (d *TMXData) Decode() ([]uint32, error) {
 	// Tile tag and CSV encodings
 	if len(d.Tiles) > 0 {
@@ -233,6 +233,8 @@ type TMXObject struct {
 	Width int `xml:"width,attr"`
 	// Height is the integer height of the object
 	Height int `xml:"height,attr"`
+	// Gid is the integer global tile ID
+	Gid int `xml:"gid,attr"`
 	// Polyline contains the TMXPolyline object if the parsed object has a polyline points string
 	Polyline TMXPolyline `xml:"polyline"`
 }


### PR DESCRIPTION
ran go fmt as well, which caused the import/comment shuffling.