### PR TITLE
safety on nil added to dispatch

### DIFF
--- a/message.go
+++ b/message.go
@@ -15,6 +15,10 @@ type MessageManager struct {
 
 // Dispatch sends a message to all subscribed handlers of the message's type
 func (mm *MessageManager) Dispatch(message Message) {
+	if mm == nil {
+		//systems that call dispatch are easier to test without invoking the whole system
+		return
+	}
 	handlers := mm.listeners[message.Type()]
 
 	for _, handler := range handlers {


### PR DESCRIPTION
The purpose of this pull request is to make it easier to write tests on systems that dispatch messages.

This way the system can be invoked and still call Engo.Mailbox.Dispatch, even if it hasn't been created by the runtime.

This can be worked around, but the reason I thought it would be worth making as a pull request is that we want to encourage testing, and taking away a hurdle to that could be helpful