### PR TITLE
HitSystem - An interface powered CollisionSystem Demo

### DIFF
--- a/common/hitsystem.go
+++ b/common/hitsystem.go
@@ -1,0 +1,133 @@
+package common
+
+import (
+	"engo.io/ecs"
+	"engo.io/engo"
+)
+
+type HitGroup byte
+
+type HitBox struct {
+	x, y, w, h float32
+}
+
+func (a HitBox) Hit(b HitBox) bool {
+	if a.x > b.x+b.w {
+		return false
+	}
+	if a.y > b.y+b.h {
+		return false
+	}
+	if b.x > a.x+a.w {
+		return false
+	}
+	if b.y > a.y+a.h {
+		return false
+	}
+	return true
+}
+
+//Minimum step a needs to take to get off of B
+func (a HitBox) MinimumStepOffD(b HitBox) (float32, float32) {
+	angle := 0 // top
+	dist := a.y + a.h - b.y
+
+	// right
+	if b.x+b.w-a.x < dist {
+		dist = b.x + b.w - a.x
+		angle = 1
+	}
+	// bottom
+	if b.y+b.h-a.y < dist {
+		dist = b.y + b.h - a.y
+		angle = 2
+	}
+	//left
+	if a.x+a.w-b.x < dist {
+		return b.x - (a.x + a.w), 0
+	}
+	switch angle {
+	case 0:
+		return 0, -dist
+	case 1:
+		return dist, 0
+	default:
+		return 0, dist
+	}
+
+}
+
+type Hitable interface {
+	ID() uint64
+	GetHitBox() HitBox
+	HitGroups() (HitGroup, HitGroup)
+	Push(float32, float32)
+}
+
+type HitMessage struct {
+	Mainob  Hitable
+	Groupob Hitable
+}
+
+func (HitMessage) Type() string {
+	return "HitMessage"
+}
+
+type HitSystem struct {
+	Solid    HitGroup
+	Entities []Hitable
+}
+
+func (hs *HitSystem) Add(h Hitable) {
+	hs.Entities = append(hs.Entities, h)
+}
+
+func (hs *HitSystem) Remove(be ecs.BasicEntity) {
+	id := be.ID()
+	del := -1
+	for k, v := range hs.Entities {
+		if v.ID() == id {
+			del = k
+			break
+		}
+	}
+	hs.Entities = append(hs.Entities[:del], hs.Entities[del+1:]...)
+}
+
+//Dispatch is to enable testing without the full engo system running
+func (hs *HitSystem) Dispatch(m engo.Message) {
+	if engo.Mailbox != nil {
+		engo.Mailbox.Dispatch(m)
+	}
+}
+
+func (hs *HitSystem) Update(dt float32) {
+	for _, v := range hs.Entities {
+		mg, _ := v.HitGroups()
+		vhb := v.GetHitBox()
+		if mg == 0 {
+			continue
+		}
+		for _, gob := range hs.Entities {
+			if gob == v {
+				continue
+			}
+			_, gg := gob.HitGroups()
+			if mg&gg == 0 {
+				continue
+			}
+			ghb := gob.GetHitBox()
+			if !vhb.Hit(ghb) {
+				continue
+			}
+			//is a Hit
+			hs.Dispatch(HitMessage{Mainob: v, Groupob: gob})
+			if mg&gg&hs.Solid != 0 {
+				dx, dy := vhb.MinimumStepOffD(ghb)
+				v.Push(dx, dy)
+			}
+		}
+
+	}
+
+}

--- a/common/hitsystem_test.go
+++ b/common/hitsystem_test.go
@@ -1,0 +1,95 @@
+package common
+
+import (
+	"testing"
+
+	"engo.io/ecs"
+	"github.com/stretchr/testify/assert"
+)
+
+//Test_MinDistance tests, that the calculated step off distance from
+// HitBox.MinStepOffD - returns a valid distance pair.
+func Test_MinDistance(t *testing.T) {
+	a := HitBox{20, 20, 20, 20}
+	b := HitBox{8, 9, 20, 20}
+	c := HitBox{9, 8, 20, 20}
+
+	//right
+	dx, dy := a.MinimumStepOffD(b)
+
+	assert.True(t, dx == 8, "right: Dx wrong = %f", dx)
+	assert.True(t, dy == 0, "right: Dy wrony = %f", dy)
+
+	//left
+	dx, dy = b.MinimumStepOffD(a)
+
+	assert.True(t, dx == -8, "left wrong = %f", dx)
+	assert.True(t, dy == 0, "left wrony = %f", dy)
+
+	//top
+	dx, dy = c.MinimumStepOffD(a)
+	assert.True(t, dx == 0, "top wrong = %f", dx)
+	assert.True(t, dy == -8, "top wrony = %f", dy)
+	//bottom
+	dx, dy = a.MinimumStepOffD(c)
+	assert.True(t, dx == 0, "bottom wrong = %f", dx)
+	assert.True(t, dy == 8, "bottom wrong = %f", dy)
+}
+
+//hitme is a super simplified hitable object.
+//For use of the system, users should combine Components to achieve the required interface
+type hitme struct {
+	ecs.BasicEntity
+	box         HitBox
+	main, group HitGroup
+}
+
+//Push moves the hitbox
+//In a full system the SpaceComponent should provide this method
+func (hm *hitme) Push(dx, dy float32) {
+	hm.box.x += dx
+	hm.box.y += dy
+}
+
+//Simply returns the stored hitbox
+//In a full system, this method can be provided by the SpaceComponent,
+//But also overridden, by the containing entity
+func (hm *hitme) GetHitBox() HitBox {
+	return hm.box
+}
+
+//HitGroups, Possibly provided by a CollisionComponent at some point.
+func (hm *hitme) HitGroups() (HitGroup, HitGroup) {
+	return hm.main, hm.group
+}
+
+func Test_Update(t *testing.T) {
+	hent := func(x, y, w, h float32, gm, gg HitGroup) *hitme {
+		nb := ecs.NewBasic()
+		return &hitme{
+			BasicEntity: nb,
+			box: HitBox{
+				x: x, y: y, w: w, h: h},
+			main:  gm,
+			group: gg,
+		}
+	}
+
+	ts := []*hitme{
+		hent(20, 20, 20, 20, 1, 0),
+		hent(7, 20, 20, 20, 0, 1),
+	}
+
+	sys := HitSystem{Solid: 1}
+
+	for _, v := range ts {
+		sys.Add(v)
+	}
+	sys.Update(0.001)
+
+	hb := ts[0].GetHitBox()
+	if hb.x != 27 {
+		t.Errorf("No solid collision happened")
+	}
+
+}

--- a/common/hitsystem_test.go
+++ b/common/hitsystem_test.go
@@ -44,9 +44,9 @@ type hitme struct {
 	main, group HitGroup
 }
 
-//Push moves the hitbox
+//Shunt moves the hitbox
 //In a full system the SpaceComponent should provide this method
-func (hm *hitme) Push(dx, dy float32) {
+func (hm *hitme) Shunt(dx, dy float32) {
 	hm.box.x += dx
 	hm.box.y += dy
 }

--- a/common/hitsystem_test.go
+++ b/common/hitsystem_test.go
@@ -63,6 +63,8 @@ func (hm *hitme) HitGroups() (HitGroup, HitGroup) {
 	return hm.main, hm.group
 }
 
+//Test_Update creates a system, sends it objects, calls update once,
+//then sees if it has done what it should to the objects
 func Test_Update(t *testing.T) {
 	hent := func(x, y, w, h float32, gm, gg HitGroup) *hitme {
 		nb := ecs.NewBasic()


### PR DESCRIPTION
The purpose of this pull request is to intorduce the idea of using interfaces to the engo.io system in the way that golang does best.

The Hit System introduced is a demo of what the Collision System could be if it used interfaces to the full.

Engo.io implements the ECS architecture where each component does not act upon itself, and so in order to use the components effectively, we have to split them up and create new objects based on fragments of them in order to keep the type system together.

My suggestion is a slightly more relaxed model, wherin the systems work on interfaces not sets of components. We allow Components a few small methods that work upon themselves and can be combined by anonymous structs on order to achieve larger interfaces.

The complex and interactive work remains the systems job, but minor adjustments, can be done as calls to an object itslelf.

Benefits of this system
--------------------------

Components can be tailored more directly to meet a systems requirements without using any of a set of different components that fulfil the required interfces instead of being forced into systems they dont fit.

It is possible for the Render System, and Collision System, to use different area boxes, (My primary motivation for making this change)

Systems only need to ask for the few methods they need, rather than having to require a large set of un-needed things.
