### PR TITLE
Equal collision

### DIFF
--- a/common/collision.go
+++ b/common/collision.go
@@ -253,8 +253,17 @@ func (c *CollisionSystem) Update(dt float32) {
 			if IsIntersecting(entityAABB, otherAABB) {
 				if cgroup&c.Solids > 0 {
 					mtd := MinimumTranslation(entityAABB, otherAABB)
-					e1.SpaceComponent.Position.X += mtd.X
-					e1.SpaceComponent.Position.Y += mtd.Y
+					if e1.CollisionComponent.Main&e2.CollisionComponent.Main&c.Solids != 0 {
+						//collision of equals (both main)
+						e1.SpaceComponent.Position.X += mtd.X / 2
+						e1.SpaceComponent.Position.Y += mtd.Y / 2
+						e2.SpaceComponent.Position.X -= mtd.X / 2
+						e2.SpaceComponent.Position.Y -= mtd.Y / 2
+					} else {
+						//collision with one main
+						e1.SpaceComponent.Position.X += mtd.X
+						e1.SpaceComponent.Position.Y += mtd.Y
+					}
 				}
 
 				//collided can now list the types of collision

--- a/common/collision.go
+++ b/common/collision.go
@@ -259,6 +259,9 @@ func (c *CollisionSystem) Update(dt float32) {
 						e1.SpaceComponent.Position.Y += mtd.Y / 2
 						e2.SpaceComponent.Position.X -= mtd.X / 2
 						e2.SpaceComponent.Position.Y -= mtd.Y / 2
+						//As the entities are no longer overlapping
+						//e2 wont collide as main
+						engo.Mailbox.Dispatch(CollisionMessage{Entity: e2, To: e1, Groups: cgroup})
 					} else {
 						//collision with one main
 						e1.SpaceComponent.Position.X += mtd.X

--- a/common/collision.go
+++ b/common/collision.go
@@ -253,7 +253,7 @@ func (c *CollisionSystem) Update(dt float32) {
 			if IsIntersecting(entityAABB, otherAABB) {
 				if cgroup&c.Solids > 0 {
 					mtd := MinimumTranslation(entityAABB, otherAABB)
-					if e2.CollisionComponent.Main&e2.CollisionComponent.Group&c.Solids != 0 {
+					if e2.CollisionComponent.Main&e1.CollisionComponent.Group&c.Solids != 0 {
 						//collision of equals (both main)
 						e1.SpaceComponent.Position.X += mtd.X / 2
 						e1.SpaceComponent.Position.Y += mtd.Y / 2

--- a/common/collision.go
+++ b/common/collision.go
@@ -253,7 +253,7 @@ func (c *CollisionSystem) Update(dt float32) {
 			if IsIntersecting(entityAABB, otherAABB) {
 				if cgroup&c.Solids > 0 {
 					mtd := MinimumTranslation(entityAABB, otherAABB)
-					if e1.CollisionComponent.Main&e2.CollisionComponent.Main&c.Solids != 0 {
+					if e2.CollisionComponent.Main&e2.CollisionComponent.Group&c.Solids != 0 {
 						//collision of equals (both main)
 						e1.SpaceComponent.Position.X += mtd.X / 2
 						e1.SpaceComponent.Position.Y += mtd.Y / 2


### PR DESCRIPTION
The purpose of this pull request is to make collisions between equal objects act equally.

Currently, the object who comes earlier in the list is checked for collision first (for loop, hard to avoid)
This first object is then moved off of the second, and so the second doesn't even register the collision when his turn comes around.

An unfortunate consequence of this is that if both elements are free to move around, the second in the list will always push the first around, but the first cannot push the second.

This recently cuased a lot of confusion for a user on gitter.

To fix this, we ask if the second element also has a main collision with the first object, (only if the collision is solid). If so we move them both back half the escape distance, and dispatch a message for both of them.
