### PR TITLE
Move canvas width/height to engo since all the builds use it

### DIFF
--- a/engo.go
+++ b/engo.go
@@ -25,6 +25,7 @@ var (
 	closeGame                 bool
 	gameWidth, gameHeight     float32
 	windowWidth, windowHeight float32
+	canvasWidth, canvasHeight float32
 	headlessWidth             = 800
 	headlessHeight            = 800
 )

--- a/engo_glfw.go
+++ b/engo_glfw.go
@@ -28,8 +28,7 @@ var (
 	cursorHResize   *glfw.Cursor
 	cursorVResize   *glfw.Cursor
 
-	canvasWidth, canvasHeight float32
-	scale                     = float32(1)
+	scale = float32(1)
 
 	Backend       string = "GLFW"
 	ResizeXOffset        = float32(0)

--- a/engo_mobile.go
+++ b/engo_mobile.go
@@ -26,8 +26,6 @@ var (
 	Gl *gl.Context
 	sz size.Event
 
-	canvasWidth, canvasHeight float32
-
 	msaaPreference int
 
 	ResizeXOffset = float32(0)

--- a/engo_mobile_bind.go
+++ b/engo_mobile_bind.go
@@ -17,8 +17,6 @@ var (
 	Gl     *gl.Context
 	worker mgl.Worker
 
-	canvasWidth, canvasHeight float32
-
 	msaaPreference int
 
 	ResizeXOffset = float32(0)


### PR DESCRIPTION
Just some cleanup, moving canvasWidth and canvasHeight to engo.go since it's used by every build tag, and now for headless mode too