### PR TITLE
clock unit tests added

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -4,6 +4,22 @@ import (
 	"time"
 )
 
+// timer is a wrapper for time.Now().UnixNano() so we can test
+// this wihout relying on time
+type timer interface {
+	Now() int64
+}
+
+// realTime is the actual timer that uses time.Now().UnixNano()
+type realTime struct{}
+
+// Now implements the timer interface
+func (realTime) Now() int64 {
+	return time.Now().UnixNano()
+}
+
+var theTimer timer = realTime{}
+
 // The amound of nano seconds in a second.
 const secondsInNano int64 = 1000000000
 
@@ -21,7 +37,7 @@ type Clock struct {
 // NewClock creates a new timer which allows you to measure ticks per seconds. Be sure to call `Tick()` whenever you
 // want a tick to occur - it does not automatically tick each frame.
 func NewClock() *Clock {
-	currStamp := time.Now().UnixNano()
+	currStamp := theTimer.Now()
 
 	clock := new(Clock)
 	clock.frameStamp = currStamp
@@ -31,7 +47,7 @@ func NewClock() *Clock {
 
 // Tick indicates a new tick/frame has occurred.
 func (c *Clock) Tick() {
-	currStamp := time.Now().UnixNano()
+	currStamp := theTimer.Now()
 
 	c.counter++
 
@@ -58,6 +74,6 @@ func (c *Clock) FPS() float32 {
 
 // Time is the number of seconds the clock has been running
 func (c *Clock) Time() float32 {
-	currStamp := time.Now().UnixNano()
+	currStamp := theTimer.Now()
 	return float32(float64(currStamp-c.startStamp) / float64(secondsInNano))
 }

--- a/clock_test.go
+++ b/clock_test.go
@@ -1,0 +1,40 @@
+package engo
+
+import (
+	"testing"
+	"time"
+)
+
+func TestClockTick(t *testing.T) {
+	clock := NewClock()
+	before := clock.counter
+	clock.Tick()
+	after := clock.counter
+	if after != before+1 {
+		t.Errorf("Tick did not increase the counter, before: %v, after: %v", before, after)
+	}
+	<-time.After(1 * time.Second)
+	clock.Tick()
+	if clock.counter != 0 {
+		t.Error("Clock's count did not reset to 0 after waiting over 1 second")
+	}
+}
+
+func TestClockFPS(t *testing.T) {
+	clock := NewClock()
+	for i := 0; i < 6; i++ {
+		<-time.After(time.Second / 6)
+		clock.Tick()
+	}
+	if !FloatEqual(clock.FPS(), float32(6)) {
+		t.Errorf("Clock's FPS did not match 6 fps, was %v", clock.FPS())
+	}
+}
+
+func TestClockTime(t *testing.T) {
+	clock := NewClock()
+	<-time.After(1 * time.Second)
+	if !FloatEqual(clock.Time(), float32(1)) {
+		t.Errorf("Clock's duration from Time did not match 1 second, was %v", clock.Time())
+	}
+}

--- a/clock_test.go
+++ b/clock_test.go
@@ -5,7 +5,18 @@ import (
 	"time"
 )
 
+// testTime is the time interface where testTime.Now() is controllable using
+// testTime.curTime
+type testTime struct {
+	curTime int64
+}
+
+func (t testTime) Now() int64 {
+	return t.curTime
+}
+
 func TestClockTick(t *testing.T) {
+	theTimer = testTime{0}
 	clock := NewClock()
 	before := clock.counter
 	clock.Tick()
@@ -13,7 +24,7 @@ func TestClockTick(t *testing.T) {
 	if after != before+1 {
 		t.Errorf("Tick did not increase the counter, before: %v, after: %v", before, after)
 	}
-	<-time.After(1 * time.Second)
+	theTimer = testTime{1000000000}
 	clock.Tick()
 	if clock.counter != 0 {
 		t.Error("Clock's count did not reset to 0 after waiting over 1 second")
@@ -21,20 +32,78 @@ func TestClockTick(t *testing.T) {
 }
 
 func TestClockFPS(t *testing.T) {
-	clock := NewClock()
-	for i := 0; i < 6; i++ {
-		<-time.After(time.Second / 6)
-		clock.Tick()
+	data := []struct {
+		fps int
+	}{
+		{5},
+		{10},
+		{20},
+		{30},
+		{60},
 	}
-	if !FloatEqualThreshold(clock.FPS(), float32(6), 1e0) {
-		t.Errorf("Clock's FPS did not match 6 fps, was %v", clock.FPS())
+	for _, d := range data {
+		theTimer = testTime{0}
+		clock := NewClock()
+		tickTime := 1000000000 / d.fps
+		curTime := int64(0)
+		for i := 0; i < d.fps; i++ {
+			curTime += int64(tickTime) + 1
+			theTimer = testTime{curTime}
+			clock.Tick()
+		}
+		if clock.FPS() != float32(d.fps) {
+			t.Errorf("Clock's FPS did not match %v fps, was %v", d.fps, clock.FPS())
+		}
+	}
+}
+
+func TestClockDelta(t *testing.T) {
+	data := []struct {
+		delta int64
+	}{
+		{6000000000},
+		{16666667},
+		{33333333},
+		{66666666},
+		{60},
+	}
+	for _, d := range data {
+		exp := float32(d.delta) / 1000000000.0
+		theTimer = testTime{0}
+		clock := NewClock()
+		theTimer = testTime{d.delta}
+		clock.Tick()
+		if clock.Delta() != exp {
+			t.Errorf("Clock's Delta did not match %v, was %v", exp, clock.Delta())
+		}
 	}
 }
 
 func TestClockTime(t *testing.T) {
-	clock := NewClock()
-	<-time.After(1 * time.Second)
-	if !FloatEqualThreshold(clock.Time(), float32(1), 1e0) {
-		t.Errorf("Clock's duration from Time did not match 1 second, was %v", clock.Time())
+	data := []struct {
+		time int64
+	}{
+		{6000000000},
+		{16666667},
+		{33333333},
+		{66666666},
+		{60},
+	}
+	for _, d := range data {
+		exp := float32(d.time) / 1000000000.0
+		theTimer = testTime{0}
+		clock := NewClock()
+		theTimer = testTime{d.time}
+		if clock.Time() != exp {
+			t.Errorf("Clock's duration from Time() did not match %v seconds, was %v", exp, clock.Time())
+		}
+	}
+}
+
+func TestTheTimerNow(t *testing.T) {
+	theTimer = realTime{}
+	res := time.Now().UnixNano() - theTimer.Now()
+	if res < -1000000 { //this is an arbitrary choice, could be smaller or larger  depending on machine testing on
+		t.Error("theTimer when it's a realTime did not produce time.Now().UnixNano()")
 	}
 }

--- a/clock_test.go
+++ b/clock_test.go
@@ -26,7 +26,7 @@ func TestClockFPS(t *testing.T) {
 		<-time.After(time.Second / 6)
 		clock.Tick()
 	}
-	if !FloatEqual(clock.FPS(), float32(6)) {
+	if !FloatEqualThreshold(clock.FPS(), float32(6), 1e0) {
 		t.Errorf("Clock's FPS did not match 6 fps, was %v", clock.FPS())
 	}
 }
@@ -34,7 +34,7 @@ func TestClockFPS(t *testing.T) {
 func TestClockTime(t *testing.T) {
 	clock := NewClock()
 	<-time.After(1 * time.Second)
-	if !FloatEqual(clock.Time(), float32(1)) {
+	if !FloatEqualThreshold(clock.Time(), float32(1), 1e0) {
 		t.Errorf("Clock's duration from Time did not match 1 second, was %v", clock.Time())
 	}
 }


### PR DESCRIPTION
Added tests to test the Clock. It adds 3 seconds to the total test time, but because the FPS ticker is setup to go once every second, it seems like it's going to have to be this way. Anyone have any suggestions that might speed this up? 