### PR TITLE
remove ecs requirement from engo

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ us a DM or [create an issue](https://github.com/EngoEngine/engo/issues/new).
 Engo is currently undergoing a lot of optimizations and constantly gets new features. However, this sometimes means things break. In order to make transitioning easier for you,
 we have a list of those changes, with the most recent being at the top. If you run into any problems, please contact us at [gitter](https://gitter.im/EngoEngine/engo).
 
+* Scenes now have `Setup(Updater)` instead of `Setup(*ecs.World)` to entirely separate engo from the ecs paradigm. ecs is no longer
+required to use the GL Context / Window / Input / Runloop management of engo.
+* Demos now require the build tag `demo`. This is so you can easily `go get engo.io/engo ./...` without waiting on building all the demos.
+* SetHeadless() was removed as it never actually did anything. It would set the opion but then it would be reset when Run was called.
 * `engo.PreloadedSpriteSingle` is now `engo.LoadedSprite`
 * `engo.Files.Load` and `engo.Files.LoadMany` have been merged into one function `engo.Files.Load` which does the same thing as `engo.Files.LoadMany` allowing an indefinite ammount of parameters to be passed in.
 * `engo` has been split in `engo` (which contains stuff about creating windows, starting the game, creating an OpenGL context, input handling, etc.) - and `common` (which contains a lot of common `System` implementations for common tasks (`RenderSystem`, `CameraSystem`, `AudioSystem`, etc.)
@@ -76,8 +80,6 @@ we have a list of those changes, with the most recent being at the top. If you r
 * Renamed `engo.io/webgl` to `engo.io/gl`, because the package handles more than only *web*gl.
 * `github.com/EngoEngine/engo` -> `engo.io/engo` - Our packages `engo`, `ecs` and `gl` should now be imported using the `engo.io` path.
 * `engi.XXX` -> `engo.XXX` - We renamed our package `engi` to `engo`.
-* SetHeadless() was removed as it never actually did anything. It would set the opion but then it would be reset when Run was called.
-* Demos now require the build tag `demo`. This is so you can easily `go get engo.io/engo ./...` without waiting on building all the demos.
 
 ## History
 

--- a/common/render_shaders_test.go
+++ b/common/render_shaders_test.go
@@ -14,7 +14,7 @@ type testScene struct{}
 
 func (*testScene) Preload() {}
 
-func (t *testScene) Setup(w *ecs.World) {}
+func (t *testScene) Setup(u engo.Updater) {}
 
 func (*testScene) Type() string { return "testScene" }
 

--- a/demos/adventure/adventure.go
+++ b/demos/adventure/adventure.go
@@ -133,7 +133,9 @@ func (*DefaultScene) Preload() {
 	engo.Input.RegisterButton(downButton, engo.S, engo.ArrowDown)
 }
 
-func (scene *DefaultScene) Setup(w *ecs.World) {
+func (scene *DefaultScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.White)
 
 	w.AddSystem(&common.RenderSystem{})

--- a/demos/animation/anim.go
+++ b/demos/animation/anim.go
@@ -41,7 +41,9 @@ func (*DefaultScene) Preload() {
 	engo.Input.RegisterButton(actionButton, engo.D, engo.ArrowRight)
 }
 
-func (scene *DefaultScene) Setup(w *ecs.World) {
+func (scene *DefaultScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.White)
 
 	w.AddSystem(&common.RenderSystem{})

--- a/demos/audio/audio.go
+++ b/demos/audio/audio.go
@@ -31,7 +31,9 @@ func (s *DefaultScene) Preload() {
 	engo.Input.RegisterButton("whoop", engo.Space)
 }
 
-func (s *DefaultScene) Setup(w *ecs.World) {
+func (s *DefaultScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.White)
 
 	w.AddSystem(&common.RenderSystem{})

--- a/demos/edgescroller/escroller.go
+++ b/demos/edgescroller/escroller.go
@@ -24,7 +24,9 @@ var (
 func (*DefaultScene) Preload() {}
 
 // Setup is called before the main loop is started
-func (*DefaultScene) Setup(w *ecs.World) {
+func (*DefaultScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.White)
 	w.AddSystem(&common.RenderSystem{})
 

--- a/demos/entityscroller/entityscroller.go
+++ b/demos/entityscroller/entityscroller.go
@@ -64,7 +64,9 @@ func (game *GameWorld) Preload() {
 	}
 }
 
-func (game *GameWorld) Setup(w *ecs.World) {
+func (game *GameWorld) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.RGBA{0x00, 0x00, 0x00, 0x00})
 
 	w.AddSystem(&common.RenderSystem{})

--- a/demos/exit/exit.go
+++ b/demos/exit/exit.go
@@ -13,7 +13,8 @@ import (
 type DefaultScene struct{}
 
 func (*DefaultScene) Preload() {}
-func (*DefaultScene) Setup(w *ecs.World) {
+func (*DefaultScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
 	w.AddSystem(&common.RenderSystem{})
 }
 

--- a/demos/falling/falling.go
+++ b/demos/falling/falling.go
@@ -35,7 +35,9 @@ func (*DefaultScene) Preload() {
 	}
 }
 
-func (*DefaultScene) Setup(w *ecs.World) {
+func (*DefaultScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.White)
 
 	// Add all of the systems

--- a/demos/headless/headless.go
+++ b/demos/headless/headless.go
@@ -49,8 +49,11 @@ func (pong *PongGame) Preload() {
 	}
 }
 
-func (pong *PongGame) Setup(w *ecs.World) {
+func (pong *PongGame) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.Black)
+
 	w.AddSystem(&common.RenderSystem{})
 	w.AddSystem(&common.CollisionSystem{Solids: 1})
 	w.AddSystem(&SpeedSystem{})

--- a/demos/hello-world/hello.go
+++ b/demos/hello-world/hello.go
@@ -24,7 +24,9 @@ func (*DefaultScene) Preload() {
 	engo.Files.Load("icon.png")
 }
 
-func (*DefaultScene) Setup(w *ecs.World) {
+func (*DefaultScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.White)
 
 	w.AddSystem(&common.RenderSystem{})

--- a/demos/hide/hide.go
+++ b/demos/hide/hide.go
@@ -27,7 +27,9 @@ func (*DefaultScene) Preload() {
 	}
 }
 
-func (*DefaultScene) Setup(w *ecs.World) {
+func (*DefaultScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.White)
 
 	w.AddSystem(&common.RenderSystem{})

--- a/demos/hud/hud.go
+++ b/demos/hud/hud.go
@@ -24,7 +24,9 @@ var (
 func (*DefaultScene) Preload() {}
 
 // Setup is called before the main loop is started
-func (*DefaultScene) Setup(w *ecs.World) {
+func (*DefaultScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.White)
 	w.AddSystem(&common.RenderSystem{})
 

--- a/demos/incrementalcamera/incrcamera.go
+++ b/demos/incrementalcamera/incrcamera.go
@@ -22,7 +22,9 @@ var (
 func (*DefaultScene) Preload() {}
 
 // Setup is called before the main loop is started
-func (*DefaultScene) Setup(w *ecs.World) {
+func (*DefaultScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.White)
 	w.AddSystem(&common.RenderSystem{})
 

--- a/demos/input/input.go
+++ b/demos/input/input.go
@@ -13,7 +13,9 @@ import (
 type DefaultScene struct{}
 
 func (*DefaultScene) Preload() {}
-func (*DefaultScene) Setup(w *ecs.World) {
+func (*DefaultScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	w.AddSystem(&common.RenderSystem{})
 	w.AddSystem(&InputSystem{})
 

--- a/demos/keyboardscroller/kbscroller.go
+++ b/demos/keyboardscroller/kbscroller.go
@@ -23,7 +23,9 @@ var (
 func (*DefaultScene) Preload() {}
 
 // Setup is called before the main loop is started
-func (*DefaultScene) Setup(w *ecs.World) {
+func (*DefaultScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.White)
 	w.AddSystem(&common.RenderSystem{})
 

--- a/demos/mouse-follow/follow.go
+++ b/demos/mouse-follow/follow.go
@@ -23,7 +23,9 @@ func (*DefaultScene) Preload() {
 	engo.Files.Load("icon.png")
 }
 
-func (*DefaultScene) Setup(w *ecs.World) {
+func (*DefaultScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.White)
 
 	w.AddSystem(&common.RenderSystem{})

--- a/demos/mouse/mouse.go
+++ b/demos/mouse/mouse.go
@@ -27,7 +27,9 @@ func (*DefaultScene) Preload() {
 	}
 }
 
-func (*DefaultScene) Setup(w *ecs.World) {
+func (*DefaultScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.White)
 
 	w.AddSystem(&common.RenderSystem{})

--- a/demos/mouserotation/rotation.go
+++ b/demos/mouserotation/rotation.go
@@ -24,7 +24,9 @@ var (
 func (*DefaultScene) Preload() {}
 
 // Setup is called before the main loop is started
-func (*DefaultScene) Setup(w *ecs.World) {
+func (*DefaultScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.White)
 	w.AddSystem(&common.RenderSystem{})
 	w.AddSystem(&common.MouseRotator{RotationSpeed: rotationSpeed})

--- a/demos/pong/pong.go
+++ b/demos/pong/pong.go
@@ -49,7 +49,9 @@ func (pong *PongGame) Preload() {
 	}
 }
 
-func (pong *PongGame) Setup(w *ecs.World) {
+func (pong *PongGame) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.Black)
 	w.AddSystem(&common.RenderSystem{})
 	w.AddSystem(&common.CollisionSystem{Solids: 1})

--- a/demos/rotation/rotation.go
+++ b/demos/rotation/rotation.go
@@ -27,7 +27,9 @@ func (game *DefaultScene) Preload() {
 	}
 }
 
-func (game *DefaultScene) Setup(w *ecs.World) {
+func (game *DefaultScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.White)
 
 	w.AddSystem(&RotationSystem{})

--- a/demos/scale/scale.go
+++ b/demos/scale/scale.go
@@ -27,7 +27,9 @@ func (*DefaultScene) Preload() {
 	}
 }
 
-func (*DefaultScene) Setup(w *ecs.World) {
+func (*DefaultScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.White)
 
 	w.AddSystem(&common.RenderSystem{})

--- a/demos/scenes/scenes.go
+++ b/demos/scenes/scenes.go
@@ -40,7 +40,9 @@ func (*IconScene) Preload() {
 	}
 }
 
-func (*IconScene) Setup(w *ecs.World) {
+func (*IconScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.White)
 
 	w.AddSystem(&common.RenderSystem{})
@@ -98,7 +100,9 @@ func (*RockScene) Preload() {
 	}
 }
 
-func (game *RockScene) Setup(w *ecs.World) {
+func (game *RockScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.White)
 
 	w.AddSystem(&common.RenderSystem{})

--- a/demos/shapes/shapes.go
+++ b/demos/shapes/shapes.go
@@ -29,7 +29,9 @@ type MyShape struct {
 func (*DefaultScene) Preload() {}
 
 // Setup is called before the main loop is started
-func (*DefaultScene) Setup(w *ecs.World) {
+func (*DefaultScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.RGBA{55, 55, 55, 255})
 	w.AddSystem(&common.RenderSystem{})
 

--- a/demos/text/text.go
+++ b/demos/text/text.go
@@ -34,7 +34,9 @@ func (*DefaultScene) Preload() {
 }
 
 // Setup is called before the main loop is started
-func (*DefaultScene) Setup(w *ecs.World) {
+func (*DefaultScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.White)
 	w.AddSystem(&common.RenderSystem{})
 

--- a/demos/tilemap/tilemap.go
+++ b/demos/tilemap/tilemap.go
@@ -30,7 +30,9 @@ func (game *GameWorld) Preload() {
 	}
 }
 
-func (game *GameWorld) Setup(w *ecs.World) {
+func (game *GameWorld) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.White)
 
 	w.AddSystem(&common.RenderSystem{})

--- a/demos/zoom/zoom.go
+++ b/demos/zoom/zoom.go
@@ -23,7 +23,9 @@ var (
 func (*DefaultScene) Preload() {}
 
 // Setup is called before the main loop is started
-func (*DefaultScene) Setup(w *ecs.World) {
+func (*DefaultScene) Setup(u engo.Updater) {
+	w, _ := u.(*ecs.World)
+
 	common.SetBackground(color.White)
 	w.AddSystem(&common.RenderSystem{})
 	w.AddSystem(&common.MouseZoomer{zoomSpeed})

--- a/engo.go
+++ b/engo.go
@@ -29,8 +29,8 @@ var (
 	// Mailbox is used by all Systems to communicate
 	Mailbox *MessageManager
 
-	currentWorld *ecs.World
-	currentScene Scene
+	currentUpdater Updater
+	currentScene   Scene
 
 	opts                      RunOptions
 	resetLoopTicker           = make(chan bool, 1)
@@ -126,6 +126,11 @@ type RunOptions struct {
 
 	// MobileWidth and MobileHeight are the width and height given from the Android/iOS OpenGL Surface used for Gomobile bind
 	MobileWidth, MobileHeight int
+
+	// Update is the function called each frame during the runLoop to update all of the
+	// systems. If left blank, it defaults to &ecs.World{}. Use this if you plan on utilizing
+	// engo's window / GL management but don't want to use the ECS paradigm.
+	Update Updater
 }
 
 // Run is called to create a window, initialize everything, and start the main loop. Once this function returns,
@@ -149,6 +154,10 @@ func Run(o RunOptions, defaultScene Scene) {
 		o.AssetsRoot = "assets"
 	}
 
+	if o.Update == nil {
+		o.Update = &ecs.World{}
+	}
+
 	opts = o
 
 	// Create input
@@ -167,6 +176,7 @@ func Run(o RunOptions, defaultScene Scene) {
 	}
 
 	Files.SetRoot(opts.AssetsRoot)
+	currentUpdater = opts.Update
 
 	// And run the game
 	if opts.HeadlessMode {

--- a/engo_glfw.go
+++ b/engo_glfw.go
@@ -221,7 +221,7 @@ func RunIteration() {
 	}
 
 	// Then update the world and all Systems
-	currentWorld.Update(Time.Delta())
+	currentUpdater.Update(Time.Delta())
 
 	// Lastly, forget keypresses and swap buffers
 	if !opts.HeadlessMode {

--- a/engo_js.go
+++ b/engo_js.go
@@ -224,7 +224,7 @@ func RunIteration() {
 	Time.Tick()
 	Input.update()
 	jsPollKeys()
-	currentWorld.Update(Time.Delta())
+	currentUpdater.Update(Time.Delta())
 	Input.Mouse.Action = Neutral
 	// TODO: this may not work, and sky-rocket the FPS
 	//  requestAnimationFrame(func(dt float32) {

--- a/engo_mobile.go
+++ b/engo_mobile.go
@@ -171,8 +171,7 @@ func RunIteration() {
 	}
 
 	// Then update the world and all Systems
-	currentWorld.Update(Time.Delta())
-
+	currentUpdater.Update(Time.Delta())
 }
 
 // SetCursor changes the cursor - not yet implemented

--- a/engo_mobile_bind.go
+++ b/engo_mobile_bind.go
@@ -159,7 +159,7 @@ func mobileDraw(defaultScene Scene) {
 	}
 
 	// Then update the world and all Systems
-	currentWorld.Update(Time.Delta())
+	currentUpdater.Update(Time.Delta())
 }
 
 //TouchEvent handles the touch events sent from Android and puts them in the InputManager

--- a/engo_test.go
+++ b/engo_test.go
@@ -14,7 +14,7 @@ type testScene struct{}
 
 func (*testScene) Preload() {}
 
-func (t *testScene) Setup(w *ecs.World) {}
+func (t *testScene) Setup(u Updater) {}
 
 func (*testScene) Type() string { return "testScene" }
 
@@ -167,7 +167,8 @@ type testRunScene struct {
 
 func (*testRunScene) Preload() {}
 
-func (t *testRunScene) Setup(w *ecs.World) {
+func (t *testRunScene) Setup(u Updater) {
+	w, _ := u.(*ecs.World)
 	w.AddSystem(&testUpdate{updates: t.updates})
 }
 


### PR DESCRIPTION
Removed the ecs requirement. Added an Update(float32) interface that is called during the runloop as well as an option to set the Updater to whatever you'd like. This allows user to use whatever paradigm and update methods they want, wihout boxing them in to ecs. This closes #331