### PR TITLE
Warning if multiple cameras are added

### DIFF
--- a/common/camera.go
+++ b/common/camera.go
@@ -48,7 +48,9 @@ type cameraEntity struct {
 	*SpaceComponent
 }
 
-// CameraSystem is a System that manages the state of the virtual camera.
+// CameraSystem is a System that manages the state of the virtual camera. Only
+// one CameraSystem can be in a World at a time. If more than one CameraSystem
+// is added to the World, it will panic.
 type CameraSystem struct {
 	x, y, z  float32
 	tracking cameraEntity // The entity that is currently being followed
@@ -60,7 +62,18 @@ type CameraSystem struct {
 }
 
 // New initializes the CameraSystem.
-func (cam *CameraSystem) New(*ecs.World) {
+func (cam *CameraSystem) New(w *ecs.World) {
+	num := 0
+	for _, sys := range w.Systems() {
+		switch sys.(type) {
+		case *CameraSystem:
+			num++
+		}
+	}
+	if num > 0 { //initalizer is called before added to w.systems
+		warning("More than one CameraSystem was added to the World. The RenderSystem adds a CameraSystem if none exist when it's added.")
+	}
+
 	if CameraBounds.Max.X == 0 && CameraBounds.Max.Y == 0 {
 		CameraBounds.Max = engo.Point{X: engo.GameWidth(), Y: engo.GameHeight()}
 	}

--- a/common/camera_test.go
+++ b/common/camera_test.go
@@ -1,6 +1,9 @@
 package common
 
 import (
+	"bytes"
+	"log"
+	"strings"
 	"testing"
 
 	"engo.io/ecs"
@@ -158,4 +161,21 @@ func TestCameraZoomTo(t *testing.T) {
 
 	cam.zoomTo(-10)
 	assert.Equal(t, cam.Z(), MinZoom, "Zooming too far, should get us to the maximum distance")
+}
+
+func TestCameraAddOnlyOne(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+
+	engo.Mailbox = &engo.MessageManager{}
+	CameraBounds = engo.AABB{Min: engo.Point{X: 0, Y: 0}, Max: engo.Point{X: 300, Y: 300}}
+	w := &ecs.World{}
+
+	w.AddSystem(&CameraSystem{})
+	w.AddSystem(&CameraSystem{})
+
+	expected := "More than one CameraSystem was added to the World. The RenderSystem adds a CameraSystem if none exist when it's added.\n"
+	if !strings.HasSuffix(buf.String(), expected) {
+		t.Error("adding more than one CameraSystem did not write expected output to log")
+	}
 }

--- a/common/render.go
+++ b/common/render.go
@@ -105,7 +105,9 @@ func (r renderEntityList) Swap(i, j int) {
 	r[i], r[j] = r[j], r[i]
 }
 
-// RenderSystem is the system that draws entities on the OpenGL surface.
+// RenderSystem is the system that draws entities on the OpenGL surface. It requires
+// a CameraSystem to work. If a CameraSystem is not in the World when you add RenderSystem
+// one is automatically added to the world.
 type RenderSystem struct {
 	entities renderEntityList
 	world    *ecs.World


### PR DESCRIPTION
Now panics when more than one `CameraSystem` is added to a `World`. Added documentation to `CameraSystem` to reflect this, and to `RenderSystem` to warn that it adds a `CameraSystem` if one isn't present. The panic also says this to provide a hint for anyone with issues. Also added tests for the panic. 