### PR TITLE
Renders the texture based on the space component's size and render component's repeat

### DIFF
--- a/common/render.go
+++ b/common/render.go
@@ -36,8 +36,10 @@ type Drawable interface {
 type TextureRepeating uint8
 
 const (
+	// NoRepeat does not repeat the texture.
+	NoRepeat TextureRepeating = iota
 	// ClampToEdge stretches the texture to the edge of the viewport.
-	ClampToEdge TextureRepeating = iota
+	ClampToEdge
 	// ClampToBorder stretches the texture to the border of the viewpport.
 	ClampToBorder
 	// Repeat repeats the texture until the border of the viewport.
@@ -56,7 +58,9 @@ type RenderComponent struct {
 	Color color.Color
 	// Drawable refers to the Texture that should be drawn
 	Drawable Drawable
-	// Repeat defines how to repeat the Texture if the viewport of the texture is larger than the texture itself
+	// Repeat defines how to repeat the Texture if the SpaceComponent of the entity
+	// is larger than the texture itself, after applying scale. Defaults to NoRepeat
+	// which allows the texture to draw entirely without regard to th SpaceComponent
 	Repeat TextureRepeating
 
 	shader Shader

--- a/common/render_shaders.go
+++ b/common/render_shaders.go
@@ -209,6 +209,8 @@ func (s *basicShader) Draw(ren *RenderComponent, space *SpaceComponent) {
 	if s.lastRepeating != ren.Repeat {
 		var val int
 		switch ren.Repeat {
+		case NoRepeat:
+			val = engo.Gl.CLAMP_TO_EDGE
 		case ClampToEdge:
 			val = engo.Gl.CLAMP_TO_EDGE
 		case ClampToBorder:
@@ -285,7 +287,16 @@ func (s *basicShader) generateBufferContent(ren *RenderComponent, space *SpaceCo
 
 	tint := colorToFloat32(ren.Color)
 
-	u, v, u2, v2 := ren.Drawable.View()
+	var u, v float32
+	u2 := float32(1)
+	v2 := float32(1)
+
+	if ren.Repeat != NoRepeat {
+		u2 = space.Width / (ren.Drawable.Width() * ren.Scale.X)
+		w *= u2
+		v2 = space.Width / (ren.Drawable.Height() * ren.Scale.Y)
+		h *= v2
+	}
 
 	var changed bool
 


### PR DESCRIPTION
This allows the RenderComponent's Repeat to work properly. It's based on the size of the SpaceComponent relative to the size of the RenderComponent's Drawable * Scale. This closes #237 

It adds a new TextureRepeat as the default, NoRepeat. If this is selected (or none are), it will draw the texture as if the View() were 0,0,1,1; just like it did before. 

However, if another one is chosen it will now look at the SpaceComponent's size to get how big it should draw the the screen, as well as the results for the View. If the SpaceComponent is smaller, it'll only draw a portion of the texture; if it's larger it'll repeat the texture based on the selected Repeat.