### PR TITLE
Add GlobalScale option

### DIFF
--- a/axis.go
+++ b/axis.go
@@ -80,11 +80,11 @@ func (am *AxisMouse) Value() float32 {
 	var diff float32
 
 	if am.direction == AxisMouseHori {
-		diff = Input.Mouse.X - am.old + (ResizeXOffset / 2)
-		am.old = Input.Mouse.X + (ResizeXOffset / 2)
+		diff = (Input.Mouse.X - am.old + (ResizeXOffset / (2 * GetGlobalScale().X)))
+		am.old = (Input.Mouse.X + (ResizeXOffset / (2 * GetGlobalScale().X)))
 	} else {
-		diff = Input.Mouse.Y - am.old + (ResizeYOffset / 2)
-		am.old = Input.Mouse.Y + (ResizeYOffset / 2)
+		diff = (Input.Mouse.Y - am.old + (ResizeYOffset / (2 * GetGlobalScale().Y)))
+		am.old = (Input.Mouse.Y + (ResizeYOffset / (2 * GetGlobalScale().Y)))
 	}
 
 	return diff

--- a/axis_test.go
+++ b/axis_test.go
@@ -427,6 +427,8 @@ func runAxisMouse(msg string, t *testing.T, x float32, y float32) {
 func TestAxisMouse(t *testing.T) {
 	Input = NewInputManager()
 
+	SetGlobalScale(Point{1, 1})
+
 	Input.RegisterAxis("mouse x", NewAxisMouse(AxisMouseHori))
 	Input.RegisterAxis("mouse y", NewAxisMouse(AxisMouseVert))
 

--- a/common/camera.go
+++ b/common/camera.go
@@ -214,11 +214,23 @@ func (cam *CameraSystem) Angle() float32 {
 }
 
 func (cam *CameraSystem) moveX(value float32) {
-	cam.moveToX(cam.x + value)
+	if cam.x+(value*engo.GetGlobalScale().X) > CameraBounds.Max.X*engo.GetGlobalScale().X {
+		cam.x = CameraBounds.Max.X * engo.GetGlobalScale().X
+	} else if cam.x+(value*engo.GetGlobalScale().X) < CameraBounds.Min.X*engo.GetGlobalScale().X {
+		cam.x = CameraBounds.Min.X * engo.GetGlobalScale().X
+	} else {
+		cam.x += value * engo.GetGlobalScale().X
+	}
 }
 
 func (cam *CameraSystem) moveY(value float32) {
-	cam.moveToY(cam.y + value)
+	if cam.y+(value*engo.GetGlobalScale().Y) > CameraBounds.Max.Y*engo.GetGlobalScale().Y {
+		cam.y = CameraBounds.Max.Y * engo.GetGlobalScale().Y
+	} else if cam.y+(value*engo.GetGlobalScale().Y) < CameraBounds.Min.Y*engo.GetGlobalScale().Y {
+		cam.y = CameraBounds.Min.Y * engo.GetGlobalScale().Y
+	} else {
+		cam.y += value * engo.GetGlobalScale().Y
+	}
 }
 
 func (cam *CameraSystem) zoom(value float32) {
@@ -230,11 +242,11 @@ func (cam *CameraSystem) rotate(value float32) {
 }
 
 func (cam *CameraSystem) moveToX(location float32) {
-	cam.x = mgl32.Clamp(location, CameraBounds.Min.X, CameraBounds.Max.X)
+	cam.x = mgl32.Clamp(location*engo.GetGlobalScale().X, CameraBounds.Min.X*engo.GetGlobalScale().X, CameraBounds.Max.X*engo.GetGlobalScale().X)
 }
 
 func (cam *CameraSystem) moveToY(location float32) {
-	cam.y = mgl32.Clamp(location, CameraBounds.Min.Y, CameraBounds.Max.Y)
+	cam.y = mgl32.Clamp(location*engo.GetGlobalScale().Y, CameraBounds.Min.Y*engo.GetGlobalScale().Y, CameraBounds.Max.Y*engo.GetGlobalScale().Y)
 }
 
 func (cam *CameraSystem) zoomTo(zoomLevel float32) {
@@ -337,14 +349,12 @@ type EntityScroller struct {
 // New adjusts CameraBounds to the bounds of EntityScroller.
 func (c *EntityScroller) New(*ecs.World) {
 	offsetX, offsetY := engo.CanvasWidth()/2, engo.CanvasHeight()/2
-	// This is to account for upper left origin
-	distY := c.TrackingBounds.Max.Y - c.TrackingBounds.Min.Y
 
-	CameraBounds.Min.X = c.TrackingBounds.Min.X + offsetX
-	CameraBounds.Min.Y = (c.TrackingBounds.Max.Y - distY) + offsetY
+	CameraBounds.Min.X = c.TrackingBounds.Min.X + (offsetX / engo.GetGlobalScale().X)
+	CameraBounds.Min.Y = c.TrackingBounds.Min.Y + (offsetY / engo.GetGlobalScale().Y)
 
-	CameraBounds.Max.X = c.TrackingBounds.Max.X - offsetX
-	CameraBounds.Max.Y = (c.TrackingBounds.Min.Y + distY) - offsetY
+	CameraBounds.Max.X = c.TrackingBounds.Max.X - (offsetX / engo.GetGlobalScale().X)
+	CameraBounds.Max.Y = c.TrackingBounds.Max.Y - (offsetY / engo.GetGlobalScale().Y)
 }
 
 // Priority implements the ecs.Prioritizer interface.

--- a/common/camera_test.go
+++ b/common/camera_test.go
@@ -16,6 +16,7 @@ var cam *CameraSystem
 func initialize() {
 	engo.Mailbox = &engo.MessageManager{}
 	CameraBounds = engo.AABB{Min: engo.Point{X: 0, Y: 0}, Max: engo.Point{X: 300, Y: 300}}
+	engo.SetGlobalScale(engo.Point{X: 1, Y: 1})
 	w := &ecs.World{}
 
 	cam = &CameraSystem{}

--- a/common/mouse.go
+++ b/common/mouse.go
@@ -178,14 +178,14 @@ func (m *MouseSystem) Update(dt float32) {
 	// Translate Mouse.X and Mouse.Y into "game coordinates"
 	switch engo.CurrentBackEnd {
 	case engo.BackEndGLFW:
-		m.mouseX = engo.Input.Mouse.X*m.camera.z*(engo.GameWidth()/engo.CanvasWidth()) + m.camera.x - (engo.GameWidth()/2)*m.camera.z
-		m.mouseY = engo.Input.Mouse.Y*m.camera.z*(engo.GameHeight()/engo.CanvasHeight()) + m.camera.y - (engo.GameHeight()/2)*m.camera.z
+		m.mouseX = engo.Input.Mouse.X*m.camera.Z()*(engo.GameWidth()/engo.CanvasWidth()) + (m.camera.X()-(engo.GameWidth()/2)*m.camera.Z())/engo.GetGlobalScale().X
+		m.mouseY = engo.Input.Mouse.Y*m.camera.Z()*(engo.GameHeight()/engo.CanvasHeight()) + (m.camera.Y()-(engo.GameHeight()/2)*m.camera.Z())/engo.GetGlobalScale().Y
 	case engo.BackEndMobile:
-		m.mouseX = engo.Input.Mouse.X*m.camera.z + m.camera.x - (engo.GameWidth()/2)*m.camera.z + (engo.ResizeXOffset / 2)
-		m.mouseY = engo.Input.Mouse.Y*m.camera.z + m.camera.y - (engo.GameHeight()/2)*m.camera.z + (engo.ResizeYOffset / 2)
+		m.mouseX = engo.Input.Mouse.X*m.camera.Z() + (m.camera.X()-(engo.GameWidth()/2)*m.camera.Z()+(engo.ResizeXOffset/2))/engo.GetGlobalScale().X
+		m.mouseY = engo.Input.Mouse.Y*m.camera.Z() + (m.camera.Y()-(engo.GameHeight()/2)*m.camera.Z()+(engo.ResizeYOffset/2))/engo.GetGlobalScale().Y
 	case engo.BackEndWeb:
-		m.mouseX = engo.Input.Mouse.X*m.camera.z + m.camera.x - (engo.GameWidth()/2)*m.camera.z + (engo.ResizeXOffset / 2)
-		m.mouseY = engo.Input.Mouse.Y*m.camera.z + m.camera.y - (engo.GameHeight()/2)*m.camera.z + (engo.ResizeYOffset / 2)
+		m.mouseX = engo.Input.Mouse.X*m.camera.Z() + (m.camera.X()-(engo.GameWidth()/2)*m.camera.Z()+(engo.ResizeXOffset/2))/engo.GetGlobalScale().X
+		m.mouseY = engo.Input.Mouse.Y*m.camera.Z() + (m.camera.Y()-(engo.GameHeight()/2)*m.camera.Z()+(engo.ResizeYOffset/2))/engo.GetGlobalScale().X
 	}
 
 	// Rotate if needed
@@ -234,7 +234,6 @@ func (m *MouseSystem) Update(dt float32) {
 		// If the Mouse component is a tracker we always update it
 		// Check if the X-value is within range
 		// and if the Y-value is within range
-
 		if e.MouseComponent.Track || e.MouseComponent.startedDragging ||
 			e.SpaceComponent.Contains(engo.Point{X: mx, Y: my}) {
 

--- a/common/render_shaders.go
+++ b/common/render_shaders.go
@@ -252,19 +252,19 @@ func (s *basicShader) Draw(ren *RenderComponent, space *SpaceComponent) {
 	if space.Rotation != 0 {
 		sin, cos := math.Sincos(space.Rotation * math.Pi / 180)
 
-		s.modelMatrix[0] = ren.Scale.X * cos
-		s.modelMatrix[1] = ren.Scale.X * sin
-		s.modelMatrix[3] = ren.Scale.Y * -sin
-		s.modelMatrix[4] = ren.Scale.Y * cos
+		s.modelMatrix[0] = ren.Scale.X * engo.GetGlobalScale().X * cos
+		s.modelMatrix[1] = ren.Scale.X * engo.GetGlobalScale().X * sin
+		s.modelMatrix[3] = ren.Scale.Y * engo.GetGlobalScale().Y * -sin
+		s.modelMatrix[4] = ren.Scale.Y * engo.GetGlobalScale().Y * cos
 	} else {
-		s.modelMatrix[0] = ren.Scale.X
+		s.modelMatrix[0] = ren.Scale.X * engo.GetGlobalScale().X
 		s.modelMatrix[1] = 0
 		s.modelMatrix[3] = 0
-		s.modelMatrix[4] = ren.Scale.Y
+		s.modelMatrix[4] = ren.Scale.Y * engo.GetGlobalScale().Y
 	}
 
-	s.modelMatrix[6] = space.Position.X
-	s.modelMatrix[7] = space.Position.Y
+	s.modelMatrix[6] = space.Position.X * engo.GetGlobalScale().X
+	s.modelMatrix[7] = space.Position.Y * engo.GetGlobalScale().Y
 
 	engo.Gl.UniformMatrix3fv(s.matrixModel, false, s.modelMatrix)
 
@@ -736,19 +736,19 @@ func (l *legacyShader) Draw(ren *RenderComponent, space *SpaceComponent) {
 	if space.Rotation != 0 {
 		sin, cos := math.Sincos(space.Rotation * math.Pi / 180)
 
-		l.modelMatrix[0] = ren.Scale.X * cos
-		l.modelMatrix[1] = ren.Scale.X * sin
-		l.modelMatrix[3] = ren.Scale.Y * -sin
-		l.modelMatrix[4] = ren.Scale.Y * cos
+		l.modelMatrix[0] = ren.Scale.X * engo.GetGlobalScale().X * cos
+		l.modelMatrix[1] = ren.Scale.X * engo.GetGlobalScale().X * sin
+		l.modelMatrix[3] = ren.Scale.Y * engo.GetGlobalScale().Y * -sin
+		l.modelMatrix[4] = ren.Scale.Y * engo.GetGlobalScale().Y * cos
 	} else {
-		l.modelMatrix[0] = ren.Scale.X
+		l.modelMatrix[0] = ren.Scale.X * engo.GetGlobalScale().X
 		l.modelMatrix[1] = 0
 		l.modelMatrix[3] = 0
-		l.modelMatrix[4] = ren.Scale.Y
+		l.modelMatrix[4] = ren.Scale.Y * engo.GetGlobalScale().Y
 	}
 
-	l.modelMatrix[6] = space.Position.X
-	l.modelMatrix[7] = space.Position.Y
+	l.modelMatrix[6] = space.Position.X * engo.GetGlobalScale().X
+	l.modelMatrix[7] = space.Position.Y * engo.GetGlobalScale().Y
 
 	engo.Gl.UniformMatrix3fv(l.matrixModel, false, l.modelMatrix)
 
@@ -1101,19 +1101,19 @@ func (l *textShader) Draw(ren *RenderComponent, space *SpaceComponent) {
 	if space.Rotation != 0 {
 		sin, cos := math.Sincos(space.Rotation * math.Pi / 180)
 
-		l.modelMatrix[0] = ren.Scale.X * cos
-		l.modelMatrix[1] = ren.Scale.X * sin
-		l.modelMatrix[3] = ren.Scale.Y * -sin
-		l.modelMatrix[4] = ren.Scale.Y * cos
+		l.modelMatrix[0] = ren.Scale.X * engo.GetGlobalScale().X * cos
+		l.modelMatrix[1] = ren.Scale.X * engo.GetGlobalScale().X * sin
+		l.modelMatrix[3] = ren.Scale.Y * engo.GetGlobalScale().Y * -sin
+		l.modelMatrix[4] = ren.Scale.Y * engo.GetGlobalScale().Y * cos
 	} else {
-		l.modelMatrix[0] = ren.Scale.X
+		l.modelMatrix[0] = ren.Scale.X * engo.GetGlobalScale().X
 		l.modelMatrix[1] = 0
 		l.modelMatrix[3] = 0
-		l.modelMatrix[4] = ren.Scale.Y
+		l.modelMatrix[4] = ren.Scale.Y * engo.GetGlobalScale().Y
 	}
 
-	l.modelMatrix[6] = space.Position.X
-	l.modelMatrix[7] = space.Position.Y
+	l.modelMatrix[6] = space.Position.X * engo.GetGlobalScale().X
+	l.modelMatrix[7] = space.Position.Y * engo.GetGlobalScale().Y
 
 	engo.Gl.UniformMatrix3fv(l.matrixModel, false, l.modelMatrix)
 	engo.Gl.DrawElements(engo.Gl.TRIANGLES, 6*len(txt.Text), engo.Gl.UNSIGNED_SHORT, 0)

--- a/demos/edgescroller/escroller.go
+++ b/demos/edgescroller/escroller.go
@@ -35,6 +35,14 @@ func (*DefaultScene) Setup(u engo.Updater) {
 
 	// Create the background; this way we'll see when we actually scroll
 	demoutils.NewBackground(w, worldWidth, worldHeight, color.RGBA{102, 153, 0, 255}, color.RGBA{102, 173, 0, 255})
+
+	// Center camera if GlobalScale is Setup
+	engo.Mailbox.Dispatch(common.CameraMessage{Axis: common.XAxis,
+		Value:       float32(worldWidth) / 2,
+		Incremental: false})
+	engo.Mailbox.Dispatch(common.CameraMessage{Axis: common.YAxis,
+		Value:       float32(worldHeight) / 2,
+		Incremental: false})
 }
 
 func (*DefaultScene) Type() string { return "Game" }

--- a/demos/incrementalcamera/incrcamera.go
+++ b/demos/incrementalcamera/incrcamera.go
@@ -30,6 +30,14 @@ func (*DefaultScene) Setup(u engo.Updater) {
 
 	demoutils.NewBackground(w, worldWidth, worldHeight, color.RGBA{102, 153, 0, 255}, color.RGBA{102, 173, 0, 255})
 
+	// Center camera if GlobalScale is Setup
+	engo.Mailbox.Dispatch(common.CameraMessage{Axis: common.XAxis,
+		Value:       float32(worldWidth) / 2,
+		Incremental: false})
+	engo.Mailbox.Dispatch(common.CameraMessage{Axis: common.YAxis,
+		Value:       float32(worldHeight) / 2,
+		Incremental: false})
+
 	// We issue one camera zoom command at the start, but it takes a while to process because we set a duration
 	engo.Mailbox.Dispatch(common.CameraMessage{
 		Axis:        common.ZAxis,

--- a/demos/keyboardscroller/kbscroller.go
+++ b/demos/keyboardscroller/kbscroller.go
@@ -34,6 +34,14 @@ func (*DefaultScene) Setup(u engo.Updater) {
 
 	// Create the background; this way we'll see when we actually scroll
 	demoutils.NewBackground(w, worldWidth, worldHeight, color.RGBA{102, 153, 0, 255}, color.RGBA{102, 173, 0, 255})
+
+	// Center camera if GlobalScale is Setup
+	engo.Mailbox.Dispatch(common.CameraMessage{Axis: common.XAxis,
+		Value:       float32(worldWidth) / 2,
+		Incremental: false})
+	engo.Mailbox.Dispatch(common.CameraMessage{Axis: common.YAxis,
+		Value:       float32(worldHeight) / 2,
+		Incremental: false})
 }
 
 func (*DefaultScene) Type() string { return "Game" }

--- a/demos/zoom/zoom.go
+++ b/demos/zoom/zoom.go
@@ -32,6 +32,14 @@ func (*DefaultScene) Setup(u engo.Updater) {
 
 	// Create the background; this way we'll see when we actually zoom
 	demoutils.NewBackground(w, worldWidth, worldHeight, color.RGBA{102, 153, 0, 255}, color.RGBA{102, 173, 0, 255})
+
+	// Center camera if GlobalScale is Setup
+	engo.Mailbox.Dispatch(common.CameraMessage{Axis: common.XAxis,
+		Value:       float32(worldWidth) / 2,
+		Incremental: false})
+	engo.Mailbox.Dispatch(common.CameraMessage{Axis: common.YAxis,
+		Value:       float32(worldHeight) / 2,
+		Incremental: false})
 }
 
 func (*DefaultScene) Type() string { return "Game" }

--- a/engo.go
+++ b/engo.go
@@ -81,6 +81,13 @@ type RunOptions struct {
 
 	Width, Height int
 
+	// GlobalScale scales all size/render components by the scale factor
+	// Any point passed less than or equal to zero will result in the scale being set to
+	// engo.Point{1, 1}.
+	// All the systems in common should scale themselves accordingly (collision, camera, render, etc)
+	// However, custom systems should be aware of this if this is set.
+	GlobalScale Point
+
 	// VSync indicates whether or not OpenGL should wait for the monitor to swp the buffers
 	VSync bool
 
@@ -156,6 +163,10 @@ func Run(o RunOptions, defaultScene Scene) {
 
 	if o.Update == nil {
 		o.Update = &ecs.World{}
+	}
+
+	if o.GlobalScale.X <= 0 || o.GlobalScale.Y <= 0 {
+		o.GlobalScale = Point{X: 1, Y: 1}
 	}
 
 	opts = o
@@ -271,4 +282,20 @@ func closeEvent() {
 
 func runHeadless(defaultScene Scene) {
 	runLoop(defaultScene, true)
+}
+
+// GetGlobalScale returns the GlobalScale factor set in the RunOptions or via
+// SetGlobalScale()
+func GetGlobalScale() Point {
+	return opts.GlobalScale
+}
+
+// SetGlobalScale sets the GlobalScale to the given dimensions. If either dimension is
+// less than or equal to zero, GlobalScale is set to (1, 1).
+func SetGlobalScale(p Point) {
+	if p.X <= 0 || p.Y <= 0 {
+		opts.GlobalScale = Point{X: 1, Y: 1}
+		return
+	}
+	opts.GlobalScale = p
 }

--- a/engo_glfw.go
+++ b/engo_glfw.go
@@ -135,7 +135,7 @@ func CreateWindow(title string, width, height int, fullscreen bool, msaa int) {
 	})
 
 	window.SetCursorPosCallback(func(window *glfw.Window, x, y float64) {
-		Input.Mouse.X, Input.Mouse.Y = float32(x)*scale, float32(y)*scale
+		Input.Mouse.X, Input.Mouse.Y = float32(x)*scale/opts.GlobalScale.X, float32(y)*scale/opts.GlobalScale.Y
 		if Input.Mouse.Action != Release && Input.Mouse.Action != Press {
 			Input.Mouse.Action = Move
 		}
@@ -143,7 +143,7 @@ func CreateWindow(title string, width, height int, fullscreen bool, msaa int) {
 
 	window.SetMouseButtonCallback(func(window *glfw.Window, b glfw.MouseButton, a glfw.Action, m glfw.ModifierKey) {
 		x, y := window.GetCursorPos()
-		Input.Mouse.X, Input.Mouse.Y = float32(x)*scale, float32(y)*scale
+		Input.Mouse.X, Input.Mouse.Y = float32(x)*scale/opts.GlobalScale.X, float32(y)*scale/opts.GlobalScale.Y
 
 		// this is only valid because we use an internal structure that is
 		// 100% compatible with glfw3.h

--- a/engo_js.go
+++ b/engo_js.go
@@ -111,22 +111,22 @@ func CreateWindow(title string, width, height int, fullscreen bool, msaa int) {
 
 	w.AddEventListener("mousemove", false, func(ev dom.Event) {
 		mm := ev.(*dom.MouseEvent)
-		Input.Mouse.X = float32(float64(mm.ClientX) * devicePixelRatio)
-		Input.Mouse.Y = float32(float64(mm.ClientY) * devicePixelRatio)
+		Input.Mouse.X = float32(float64(mm.ClientX)*devicePixelRatio) / opts.GlobalScale.X
+		Input.Mouse.Y = float32(float64(mm.ClientY)*devicePixelRatio) / opts.GlobalScale.Y
 		//Mouse.Action = MOVE
 	})
 
 	w.AddEventListener("mousedown", false, func(ev dom.Event) {
 		mm := ev.(*dom.MouseEvent)
-		Input.Mouse.X = float32(float64(mm.ClientX) * devicePixelRatio)
-		Input.Mouse.Y = float32(float64(mm.ClientY) * devicePixelRatio)
+		Input.Mouse.X = float32(float64(mm.ClientX)*devicePixelRatio) / opts.GlobalScale.X
+		Input.Mouse.Y = float32(float64(mm.ClientY)*devicePixelRatio) / opts.GlobalScale.Y
 		Input.Mouse.Action = Press
 	})
 
 	w.AddEventListener("mouseup", false, func(ev dom.Event) {
 		mm := ev.(*dom.MouseEvent)
-		Input.Mouse.X = float32(float64(mm.ClientX) * devicePixelRatio)
-		Input.Mouse.Y = float32(float64(mm.ClientY) * devicePixelRatio)
+		Input.Mouse.X = float32(float64(mm.ClientX)*devicePixelRatio) / opts.GlobalScale.X
+		Input.Mouse.Y = float32(float64(mm.ClientY)*devicePixelRatio) / opts.GlobalScale.Y
 		Input.Mouse.Action = Release
 	})
 }
@@ -136,7 +136,7 @@ func DestroyWindow() {}
 
 // CursorPos returns the current cursor position
 func CursorPos() (x, y float32) {
-	return Input.Mouse.X, Input.Mouse.Y
+	return Input.Mouse.X * opts.GlobalScale.X, Input.Mouse.Y * opts.GlobalScale.Y
 }
 
 // SetTitle changes the title of the page to the given string

--- a/engo_mobile.go
+++ b/engo_mobile.go
@@ -140,8 +140,8 @@ func runLoop(defaultScene Scene, headless bool) {
 				// after this one is shown. - FPS is ignored here!
 				a.Send(paint.Event{})
 			case touch.Event:
-				Input.Mouse.X = e.X
-				Input.Mouse.Y = e.Y
+				Input.Mouse.X = e.X / opts.GlobalScale.X
+				Input.Mouse.Y = e.Y / opts.GlobalScale.Y
 				switch e.Type {
 				case touch.TypeBegin:
 					Input.Mouse.Action = Press

--- a/engo_mobile_bind.go
+++ b/engo_mobile_bind.go
@@ -164,8 +164,8 @@ func mobileDraw(defaultScene Scene) {
 
 //TouchEvent handles the touch events sent from Android and puts them in the InputManager
 func TouchEvent(x, y, action int) {
-	Input.Mouse.X = float32(x)
-	Input.Mouse.Y = float32(y)
+	Input.Mouse.X = float32(x) / opts.GlobalScale.X
+	Input.Mouse.Y = float32(y) / opts.GlobalScale.Y
 	switch action {
 	case 0:
 		Input.Mouse.Action = Press

--- a/input_keys_glfw.go
+++ b/input_keys_glfw.go
@@ -54,7 +54,7 @@ const (
 	KeyPause Key = Key(glfw.KeyPause)
 	// KeyScrollLock represents the scroll lock keyboard key
 	KeyScrollLock Key = Key(glfw.KeyScrollLock)
-	// KeyAllowLeft represents the arrow left keyboard key
+	// KeyArrowLeft represents the arrow left keyboard key
 	KeyArrowLeft Key = Key(glfw.KeyLeft)
 	// KeyArrowRight represents the arrow right keyboard key
 	KeyArrowRight Key = Key(glfw.KeyRight)


### PR DESCRIPTION
Added a GlobalScale option that'll scale the entire game by that amount.
If the Scale is set, it'll adjust mouse clicks and rendering, but if the
user is utilizing mouse positioning or a custom render system, they'll
need to be aware of if this is set and what it sets to. Default is just
engo.Point{1,1}. Fixes #270 