### PR TITLE
added not flags and the add by interface to work with new ecs setup

### DIFF
--- a/common/animation.go
+++ b/common/animation.go
@@ -113,7 +113,8 @@ func (a *AnimationSystem) Add(basic *ecs.BasicEntity, anim *AnimationComponent, 
 }
 
 // AddByInterface Allows an Entity to be added directly using the Animtionable interface. which every entity containing the BasicEntity,AnimationComponent,and RenderComponent anonymously, automatically satisfies.
-func (a *AnimationSystem) AddByInterface(o Animationable) {
+func (a *AnimationSystem) AddByInterface(i ecs.Identifier) {
+	o, _ := i.(Animationable)
 	a.Add(o.GetBasicEntity(), o.GetAnimationComponent(), o.GetRenderComponent())
 }
 

--- a/common/audio.go
+++ b/common/audio.go
@@ -56,7 +56,8 @@ func (a *AudioSystem) Add(basic *ecs.BasicEntity, audio *AudioComponent) {
 // AddByInterface Allows an Entity to be added directly using the Audioable interface,
 // which every entity containing the BasicEntity and AnimationComponent anonymously,
 // automatically satisfies.
-func (a *AudioSystem) AddByInterface(o Audioable) {
+func (a *AudioSystem) AddByInterface(i ecs.Identifier) {
+	o, _ := i.(Audioable)
 	a.Add(o.GetBasicEntity(), o.GetAudioComponent())
 }
 

--- a/common/collision.go
+++ b/common/collision.go
@@ -198,7 +198,8 @@ func (c *CollisionSystem) Add(basic *ecs.BasicEntity, collision *CollisionCompon
 }
 
 // AddByInterface Provides a simple way to add an entity to the system that satisfies Collisionable. Any entity containing, BasicEntity,CollisionComponent, and SpaceComponent anonymously, automatically does this.
-func (c *CollisionSystem) AddByInterface(o Collisionable) {
+func (c *CollisionSystem) AddByInterface(i ecs.Identifier) {
+	o, _ := i.(Collisionable)
 	c.Add(o.GetBasicEntity(), o.GetCollisionComponent(), o.GetSpaceComponent())
 }
 

--- a/common/interfaces.go
+++ b/common/interfaces.go
@@ -22,6 +22,11 @@
 //
 // Note: The names have not been contracted for consistency, the interface is
 // *Collisionable* not *Collidable*.
+//
+// Not-Ables
+//
+// The Not-Ables are interfaces of components used to flag entities to not add to the system,
+// for use with the ecs.World.AddSystemInterface
 
 package common
 
@@ -132,4 +137,56 @@ type Collisionable interface {
 	BasicFace
 	CollisionFace
 	SpaceFace
+}
+
+// Not-Ables
+
+type NotAnimationComponent struct{}
+
+func (n *NotAnimationComponent) GetNotAnimationComponent() *NotAnimationComponent {
+	return n
+}
+
+type NotAnimationable interface {
+	GetNotAnimationComponent() *NotAnimationComponent
+}
+
+type NotMouseComponent struct{}
+
+func (n *NotMouseComponent) GetNotMouseComponent() *NotMouseComponent {
+	return n
+}
+
+type NotMouseable interface {
+	GetNotMouseComponent() *NotMouseComponent
+}
+
+type NotAudioComponent struct{}
+
+func (n *NotAudioComponent) GetNotAudioComponent() *NotAudioComponent {
+	return n
+}
+
+type NotAudioable interface {
+	GetNotAudioComponent() *NotAudioComponent
+}
+
+type NotRenderComponent struct{}
+
+func (n *NotRenderComponent) GetNotRenderComponent() *NotRenderComponent {
+	return n
+}
+
+type NotRenderable interface {
+	GetNotRenderComponent() *NotRenderComponent
+}
+
+type NotCollisionComponent struct{}
+
+func (n *NotCollisionComponent) GetNotCollisionComponent() *NotCollisionComponent {
+	return n
+}
+
+type NotCollisionable interface {
+	GetNotCollisionComponent() *NotCollisionComponent
 }

--- a/common/mouse.go
+++ b/common/mouse.go
@@ -155,7 +155,8 @@ func (m *MouseSystem) Add(basic *ecs.BasicEntity, mouse *MouseComponent, space *
 }
 
 // AddByInterface adds the Entity to the system as long as it satisfies, Mouseable.  Any Entity containing a BasicEntity,MouseComponent, and RenderComponent, automatically does this.
-func (m *MouseSystem) AddByInterface(o Mouseable) {
+func (m *MouseSystem) AddByInterface(i ecs.Identifier) {
+	o, _ := i.(Mouseable)
 	m.Add(o.GetBasicEntity(), o.GetMouseComponent(), o.GetSpaceComponent(), o.GetRenderComponent())
 }
 

--- a/common/render.go
+++ b/common/render.go
@@ -243,7 +243,8 @@ func (rs *RenderSystem) EntityExists(basic *ecs.BasicEntity) int {
 }
 
 // AddByInterface adds any Renderable to the render system. Any Entity containing a BasicEntity,RenderComponent, and SpaceComponent anonymously does this automatically
-func (rs *RenderSystem) AddByInterface(o Renderable) {
+func (rs *RenderSystem) AddByInterface(i ecs.Identifier) {
+	o, _ := i.(Renderable)
 	rs.Add(o.GetBasicEntity(), o.GetRenderComponent(), o.GetSpaceComponent())
 }
 


### PR DESCRIPTION
Added not flags to the systems so you can add the "Not" components to entities you want to flag as not part of a system when utilizing the auto-add ecs.World.SystemInterface() function. Also changed AddByInterface to take a ecs.Identifier instead of the specific -able to be more generic and work with the ecs implementation.

Fixes #387 