### PR TITLE
changed build tags to include ios

### DIFF
--- a/engo_glfw.go
+++ b/engo_glfw.go
@@ -1,4 +1,5 @@
-//+build !netgo,!android
+// +build darwin,!arm,!arm64 linux windows
+// +build !ios,!android,!netgo
 
 package engo
 

--- a/engo_mobile.go
+++ b/engo_mobile.go
@@ -1,4 +1,5 @@
-//+build android,!mobilebind
+//+build android darwin,arm darwin,arm64 ios
+//+build !mobilebind
 
 package engo
 

--- a/input_keys.go
+++ b/input_keys.go
@@ -1,4 +1,4 @@
-//+build netgo android
+//+build netgo android ios darwin,arm darwin,arm64
 
 package engo
 

--- a/input_keys_glfw.go
+++ b/input_keys_glfw.go
@@ -1,4 +1,5 @@
-//+build !netgo,!android
+// +build darwin,!arm,!arm64 linux windows
+// +build !ios,!android,!netgo
 
 package engo
 


### PR DESCRIPTION
Closes #371, #306, and #370. Build tags now properly include building and binding iOS using gomobile. Updated ergo.io/gl to also use these build tags.