### PR TITLE
fixed duplicate movement in CollisionSystem

### DIFF
--- a/common/collision.go
+++ b/common/collision.go
@@ -273,6 +273,14 @@ func (c *CollisionSystem) Update(dt float32) {
 				//collided can now list the types of collision
 				collided = collided | cgroup
 				engo.Mailbox.Dispatch(CollisionMessage{Entity: e1, To: e2, Groups: cgroup})
+
+				//update the position tracker of e1
+				entityAABB = e1.SpaceComponent.AABB()
+				offset := engo.Point{X: e1.CollisionComponent.Extra.X / 2, Y: e1.CollisionComponent.Extra.Y / 2}
+				entityAABB.Min.X -= offset.X
+				entityAABB.Min.Y -= offset.Y
+				entityAABB.Max.X += offset.X
+				entityAABB.Max.Y += offset.Y
 			}
 		}
 


### PR DESCRIPTION
Bug:
When a CollisionEntity with the Main field set is intersecting two or more other entities, (for example, when it's pushed into the ground by gravity where two ground tiles meet) it is affected by both Minimal Translations, when one would be sufficient.
Fix:
After applying the first MinimalTranslation the new position of the CollisionEntity is used as further reference to all other isIntersecting checks