### PR TITLE
Fixes race conditions 

### DIFF
--- a/engo.go
+++ b/engo.go
@@ -1,4 +1,4 @@
-package engo
+package engo // import "engo.io/engo"
 
 import (
 	"fmt"

--- a/engo.go
+++ b/engo.go
@@ -1,8 +1,9 @@
-package engo // import "engo.io/engo"
+package engo
 
 import (
 	"fmt"
 	"log"
+	"sync"
 
 	"engo.io/ecs"
 )
@@ -35,6 +36,7 @@ var (
 	opts                      RunOptions
 	resetLoopTicker           = make(chan bool, 1)
 	closeGame                 bool
+	closerMutex               *sync.RWMutex
 	gameWidth, gameHeight     float32
 	windowWidth, windowHeight float32
 	canvasWidth, canvasHeight float32
@@ -253,7 +255,9 @@ func ScaleOnResize() bool {
 
 // Exit is the safest way to close your game, as `engo` will correctly attempt to close all windows, handlers and contexts
 func Exit() {
+	closerMutex.Lock()
 	closeGame = true
+	closerMutex.Unlock()
 }
 
 // GameWidth returns the current game width

--- a/engo.go
+++ b/engo.go
@@ -30,9 +30,9 @@ var (
 	// Mailbox is used by all Systems to communicate
 	Mailbox *MessageManager
 
-	currentUpdater Updater
-	currentScene   Scene
-
+	currentUpdater            Updater
+	currentScene              Scene
+	sceneMutex                *sync.RWMutex
 	opts                      RunOptions
 	resetLoopTicker           = make(chan bool, 1)
 	closeGame                 bool
@@ -146,6 +146,8 @@ type RunOptions struct {
 // the game window has been closed already. You can supply a lot of options within `RunOptions`, and your starting
 // `Scene` should be defined in `defaultScene`.
 func Run(o RunOptions, defaultScene Scene) {
+	closerMutex, sceneMutex = &sync.RWMutex{}, &sync.RWMutex{}
+
 	// Setting defaults
 	if o.FPSLimit == 0 {
 		o.FPSLimit = 60
@@ -271,11 +273,13 @@ func GameHeight() float32 {
 }
 
 func closeEvent() {
+	sceneMutex.RLock()
 	for _, scenes := range scenes {
 		if exiter, ok := scenes.scene.(Exiter); ok {
 			exiter.Exit()
 		}
 	}
+	sceneMutex.RUnlock()
 
 	if !opts.OverrideCloseAction {
 		Exit()

--- a/engo_glfw.go
+++ b/engo_glfw.go
@@ -270,9 +270,12 @@ Outer:
 		select {
 		case <-ticker.C:
 			RunIteration()
+			closerMutex.RLock()
 			if closeGame {
+				closerMutex.RUnlock()
 				break Outer
 			}
+			closerMutex.RUnlock()
 			if !headless && window.ShouldClose() {
 				closeEvent()
 			}


### PR DESCRIPTION
Fixes issue #575 : when running a game and closing it via Terminal via `os.Interrupt` or `syscall.SIGTERM` (aka CTRL+C) 8 race conditions are detected if the game is built or run with the `-race` flag

