### PR TITLE
#584 Improved message manager 

### DIFF
--- a/message.go
+++ b/message.go
@@ -1,9 +1,30 @@
 package engo
 
-import "sync"
+import (
+	"errors"
+	"sync"
+)
 
 //A MessageHandler is used to dispatch a message to the subscribed handler.
 type MessageHandler func(msg Message)
+
+// in order to track handlers, each handler will get a unique ID
+type MessageHandlerId uint64
+
+var currentHandlerId MessageHandlerId
+
+func init() {
+	currentHandlerId = 0
+}
+func getNewHandlerId() MessageHandlerId {
+	currentHandlerId++
+	return currentHandlerId
+}
+
+type HandlerIDPair struct {
+	MessageHandlerId
+	MessageHandler
+}
 
 // A Message is used to send messages within the MessageManager
 type Message interface {
@@ -12,12 +33,11 @@ type Message interface {
 
 // MessageManager manages messages and subscribed handlers
 type MessageManager struct {
-
 	// this mutex will prevent race
 	// conditions on listeners and
 	// sync its state across the game
 	sync.RWMutex
-	listeners map[string][]MessageHandler
+	listeners map[string][]HandlerIDPair
 }
 
 // Dispatch sends a message to all subscribed handlers of the message's type
@@ -29,19 +49,47 @@ func (mm *MessageManager) Dispatch(message Message) {
 	mm.RLock()
 	defer mm.RUnlock()
 	for _, handler := range handlers {
-		handler(message)
+		handler.MessageHandler(message)
 	}
 
 }
 
 // Listen subscribes to the specified message type and calls the specified handler when fired
-func (mm *MessageManager) Listen(messageType string, handler MessageHandler) {
+func (mm *MessageManager) Listen(messageType string, handler MessageHandler) MessageHandlerId {
 	mm.Lock()
 	defer mm.Unlock()
 	if mm.listeners == nil {
-		mm.listeners = make(map[string][]MessageHandler)
+		mm.listeners = make(map[string][]HandlerIDPair)
 	}
-	mm.listeners[messageType] = append(mm.listeners[messageType], handler)
+	handlerID := getNewHandlerId()
+	newHandlerIdPair := HandlerIDPair{MessageHandlerId: handlerID, MessageHandler: handler}
+	mm.listeners[messageType] = append(mm.listeners[messageType], newHandlerIdPair)
+	return handlerID
+}
+
+// StopListen removes a previously added handler from the listener queue
+func (mm *MessageManager) StopListen(messageType string, handlerId MessageHandlerId) error {
+	// first, we need to find the handler to remove or return an error if that's not possible
+	indexOfHandler := -1
+	for i, activeHandler := range mm.listeners[messageType] {
+		if activeHandler.MessageHandlerId == handlerId {
+			indexOfHandler = i
+			break
+		}
+	}
+	if indexOfHandler == -1 {
+		return errors.New("Trying to remove handler that does not exist")
+	}
+	mm.listeners[messageType] = append(mm.listeners[messageType][:indexOfHandler], mm.listeners[messageType][indexOfHandler+1:]...)
+	return nil
+}
+
+func (mm *MessageManager) ListenOnce(messageType string, handler MessageHandler) {
+	handlerId := MessageHandlerId(0)
+	handlerId = mm.Listen(messageType, func(msg Message) {
+		handler(msg)
+		mm.StopListen(messageType, handlerId)
+	})
 }
 
 // WindowResizeMessage is a message that's being dispatched whenever the game window is being resized by the gamer

--- a/message.go
+++ b/message.go
@@ -92,6 +92,7 @@ func (mm *MessageManager) clearRemovedHandlers() {
 			mm.removeHandler(messageType, handlerId)
 		}
 	}
+	mm.handlersToRemove = make(map[string][]MessageHandlerId)
 }
 
 // Removes a single handler from the handler queue, called during cleanup of all handlers scheduled for removal

--- a/message_test.go
+++ b/message_test.go
@@ -53,14 +53,6 @@ func TestMessageCounterWithRemoval(t *testing.T) {
 	}
 }
 
-func TestRemovalOfNonexistentHandler(t *testing.T) {
-	mailbox := &MessageManager{}
-	err := mailbox.StopListen("testMessageCounter", MessageHandlerId(42))
-	if err == nil {
-		t.Error("StopListen should return an error in case the handler to remove doesn't exist")
-	}
-}
-
 func TestMessageListenOnce(t *testing.T) {
 	mailbox := &MessageManager{}
 	msg := testMessageCounter{}

--- a/message_test.go
+++ b/message_test.go
@@ -2,25 +2,82 @@ package engo
 
 import "testing"
 
-type testMessage struct {
-	success bool
+type testMessageCounter struct {
+	counter int
 }
 
-func (testMessage) Type() string {
-	return "testMessage"
+func (testMessageCounter) Type() string {
+	return "testMessageCounter"
 }
 
-func TestMessages(t *testing.T) {
+func TestMessageCounterSimple(t *testing.T) {
 	mailbox := &MessageManager{}
-	msg := testMessage{}
-	mailbox.Listen("testMessage", func(message Message) {
-		m, ok := message.(*testMessage)
-		if ok {
-			m.success = true
+	msg := testMessageCounter{}
+	mailbox.Listen("testMessageCounter", func(message Message) {
+		m, ok := message.(*testMessageCounter)
+		if !ok {
+			t.Error("Message should be of type testMessageCounter")
 		}
+		m.counter++
 	})
 	mailbox.Dispatch(&msg)
-	if !msg.success {
-		t.Error("huh")
+	if msg.counter != 1 {
+		t.Error("Message should have been received 1 times by now")
+	}
+	mailbox.Dispatch(&msg)
+	if msg.counter != 2 {
+		t.Error("Message should have been received 2 times by now")
+	}
+}
+
+func TestMessageCounterWithRemoval(t *testing.T) {
+	mailbox := &MessageManager{}
+	msg := testMessageCounter{}
+	handlerId := mailbox.Listen("testMessageCounter", func(message Message) {
+		m, ok := message.(*testMessageCounter)
+		if !ok {
+			t.Error("Message should be of type testMessageCounter")
+		}
+		m.counter++
+	})
+	mailbox.Dispatch(&msg)
+	if msg.counter != 1 {
+		t.Error("Message should have been received 1 times by now")
+	}
+
+	mailbox.StopListen("testMessageCounter", handlerId)
+
+	mailbox.Dispatch(&msg)
+	if msg.counter != 1 {
+		t.Error("Message should have been received exactly 1 times since its handler was removed from listeners")
+	}
+}
+
+func TestRemovalOfNonexistentHandler(t *testing.T) {
+	mailbox := &MessageManager{}
+	err := mailbox.StopListen("testMessageCounter", MessageHandlerId(42))
+	if err == nil {
+		t.Error("StopListen should return an error in case the handler to remove doesn't exist")
+	}
+}
+
+func TestMessageListenOnce(t *testing.T) {
+	mailbox := &MessageManager{}
+	msg := testMessageCounter{}
+	mailbox.ListenOnce("testMessageCounter", func(message Message) {
+		m, ok := message.(*testMessageCounter)
+		if !ok {
+			t.Error("Message should be of type testMessageCounter")
+		}
+		m.counter++
+	})
+	mailbox.Dispatch(&msg)
+	if msg.counter != 1 {
+		t.Error("Message should have been received 1 times by now")
+	}
+
+	mailbox.Dispatch(&msg)
+	if msg.counter != 1 {
+		t.Error("Message should have been received exactly 1 times since its been added by ListenOnce()")
 	}
 }

--- a/scene.go
+++ b/scene.go
@@ -107,7 +107,7 @@ func SetScene(s Scene, forceNewWorld bool) {
 	if doSetup {
 		s.Preload()
 
-		wrapper.mailbox.listeners = make(map[string][]MessageHandler)
+		wrapper.mailbox.listeners = make(map[string][]HandlerIDPair)
 
 		s.Setup(wrapper.update)
 	} else {


### PR DESCRIPTION
Added StopListen and ListenOnce to the MessageManager

Taking a first shot to resolve #584 
As this is my first Golang project, please check the code for beginner mistakes :)

What I'm currently not sure about: Locking
Dispatch() only holds a RLock when dispatching the individual handlers. However, StopListen() might (and ListenOnce certainly WILL) modify the handlers list while Dispatch() is iterating over it. Not entirely sure, but this seems very problematic. 

Potential solution: Have Dispatch() use Lock() instead of RLock(). Have StopListen() test the lock. If the lock is open, we can simply remove the handler without special care. If it's already locked (indicating that Dispatch() is currently running), add the MessageHandlerID to some "to be deleted" list. After processing handlers, Dispatch() goes ahead and removes all handlers in the "to be deleted" list. 
Would an approach like that work? Are there cases where StopListen() might run into a lock, even if it's not originating from Dispatch()?
