### PR TITLE
add panic if shaders don't compile

### DIFF
--- a/common/render.go
+++ b/common/render.go
@@ -164,7 +164,9 @@ func (rs *RenderSystem) New(w *ecs.World) {
 	addCameraSystemOnce(w)
 
 	if !engo.Headless() {
-		initShaders(w)
+		if err := initShaders(w); err != nil {
+			panic(err)
+		}
 		engo.Gl.Enable(engo.Gl.MULTISAMPLE)
 	}
 


### PR DESCRIPTION
This will allow custom shaders to know if their shaders have errors and don't work