### PR TITLE
Fix a race condition when engo glfw is closed.

### DIFF
--- a/engo_glfw.go
+++ b/engo_glfw.go
@@ -275,7 +275,9 @@ func runLoop(defaultScene Scene, headless bool) {
 		case <-ticker.C:
 			RunIteration()
 			if !headless && Window.ShouldClose() {
+				ticker.Stop()
 				closeEvent()
+				return
 			}
 		case <-resetLoopTicker:
 			ticker.Stop()


### PR DESCRIPTION
Since one ticker.C element can be buffered in case the ticker falls
behind a bit, there is a chance that when the glfw window is closed,
closeEvent() will be fired twice.