### PR TITLE
view-culling for basic shader

### DIFF
--- a/common/render.go
+++ b/common/render.go
@@ -308,6 +308,7 @@ func (rs *RenderSystem) Update(dt float32) {
 	engo.Gl.Clear(engo.Gl.COLOR_BUFFER_BIT)
 
 	preparedCullingShaders := make(map[CullingShader]struct{})
+	var lastCullingShader CullingShader
 
 	// TODO: it's linear for now, but that might very well be a bad idea
 	for _, e := range rs.entities {
@@ -319,7 +320,8 @@ func (rs *RenderSystem) Update(dt float32) {
 		shader := e.RenderComponent.shader
 
 		cullingShader, isCullingShader := shader.(CullingShader)
-		if isCullingShader && shader != rs.currentShader {
+		if isCullingShader && cullingShader != lastCullingShader {
+			lastCullingShader = cullingShader
 			if _, isPrepared := preparedCullingShaders[cullingShader]; !isPrepared {
 				cullingShader.PrepareCulling()
 				preparedCullingShaders[cullingShader] = struct{}{}

--- a/common/render.go
+++ b/common/render.go
@@ -319,7 +319,7 @@ func (rs *RenderSystem) Update(dt float32) {
 		shader := e.RenderComponent.shader
 
 		cullingShader, isCullingShader := shader.(CullingShader)
-		if isCullingShader {
+		if isCullingShader && shader != rs.currentShader {
 			if _, isPrepared := preparedCullingShaders[cullingShader]; !isPrepared {
 				cullingShader.PrepareCulling()
 				preparedCullingShaders[cullingShader] = struct{}{}

--- a/common/render_shaders.go
+++ b/common/render_shaders.go
@@ -211,8 +211,6 @@ func (s *basicShader) PrepareCulling() {
 
 func (s *basicShader) ShouldDraw(rc *RenderComponent, sc *SpaceComponent) bool {
 	aabb := sc.AABB()
-	aabb.Min.Multiply(rc.Scale)
-	aabb.Max.Multiply(rc.Scale)
 
 	min := aabb.Min.MultiplyMatrixVector(s.cullingMatrix)
 	max := aabb.Max.MultiplyMatrixVector(s.cullingMatrix)

--- a/common/render_shaders.go
+++ b/common/render_shaders.go
@@ -210,15 +210,23 @@ func (s *basicShader) PrepareCulling() {
 }
 
 func (s *basicShader) ShouldDraw(rc *RenderComponent, sc *SpaceComponent) bool {
-	aabb := sc.AABB()
+	tsc := SpaceComponent{
+		Position: sc.Position,
+		Width:    rc.Drawable.Width() * rc.Scale.X,
+		Height:   rc.Drawable.Height() * rc.Scale.Y,
+		Rotation: sc.Rotation,
+	}
 
-	min := aabb.Min.MultiplyMatrixVector(s.cullingMatrix)
-	max := aabb.Max.MultiplyMatrixVector(s.cullingMatrix)
+	c := tsc.Corners()
+	c[0].MultiplyMatrixVector(s.cullingMatrix)
+	c[1].MultiplyMatrixVector(s.cullingMatrix)
+	c[2].MultiplyMatrixVector(s.cullingMatrix)
+	c[3].MultiplyMatrixVector(s.cullingMatrix)
 
-	return !((min.X < -1 && max.X < -1) || // Both points left of the "viewport"
-		(min.X > 1 && max.X > 1) || // Both points right of the "viewport"
-		(min.Y < -1 && max.Y < -1) || // Both points above of the "viewport"
-		(min.Y > 1 && max.Y > 1)) // Both points below of the "viewport"
+	return !((c[0].X < -1 && c[1].X < -1 && c[2].X < -1 && c[3].X < -1) || // All points left of the "viewport"
+		(c[0].X > 1 && c[1].X > 1 && c[2].X > 1 && c[3].X > 1) || // All points right of the "viewport"
+		(c[0].Y < -1 && c[1].Y < -1 && c[2].Y < -1 && c[3].Y < -1) || // All points above of the "viewport"
+		(c[0].Y > 1 && c[1].Y > 1 && c[2].Y > 1 && c[3].Y > 1)) // All points below of the "viewport"
 }
 
 func (s *basicShader) Draw(ren *RenderComponent, space *SpaceComponent) {

--- a/common/render_shaders.go
+++ b/common/render_shaders.go
@@ -172,6 +172,7 @@ func (s *basicShader) Pre() {
 	engo.Gl.EnableVertexAttribArray(s.inPosition)
 	engo.Gl.EnableVertexAttribArray(s.inTexCoords)
 	engo.Gl.EnableVertexAttribArray(s.inColor)
+	s.PrepareCulling()
 
 	// The matrixProjView shader uniform is projection * view.
 	// We do the multiplication on the CPU instead of sending each matrix to the shader and letting the GPU do the multiplication,
@@ -214,13 +215,13 @@ func (s *basicShader) ShouldDraw(rc *RenderComponent, sc *SpaceComponent) bool {
 	aabb.Min.Multiply(rc.Scale)
 	aabb.Max.Multiply(rc.Scale)
 
-	minVtx := engo.MultiplyMatrixVector(s.cullingMatrix, []float32{aabb.Min.X, aabb.Min.Y})
-	maxVtx := engo.MultiplyMatrixVector(s.cullingMatrix, []float32{aabb.Max.X, aabb.Max.Y})
+	min := aabb.Min.MultiplyMatrixVector(s.cullingMatrix)
+	max := aabb.Max.MultiplyMatrixVector(s.cullingMatrix)
 
-	return !((minVtx[0] < -1 && maxVtx[0] < -1) || // Both points left of the "viewport"
-		(minVtx[0] > 1 && maxVtx[0] > 1) || // Both points right of the "viewport"
-		(minVtx[1] < -1 && maxVtx[1] < -1) || // Both points above of the "viewport"
-		(minVtx[1] > 1 && maxVtx[1] > 1)) // Both points below of the "viewport"
+	return !((min.X < -1 && max.X < -1) || // Both points left of the "viewport"
+		(min.X > 1 && max.X > 1) || // Both points right of the "viewport"
+		(min.Y < -1 && max.Y < -1) || // Both points above of the "viewport"
+		(min.Y > 1 && max.Y > 1)) // Both points below of the "viewport"
 }
 
 func (s *basicShader) Draw(ren *RenderComponent, space *SpaceComponent) {

--- a/common/render_shaders.go
+++ b/common/render_shaders.go
@@ -80,6 +80,14 @@ type Shader interface {
 	SetCamera(*CameraSystem)
 }
 
+// CullingShader when implemented can be used in the RenderSystem to test if an entity should be rendered.
+type CullingShader interface {
+	Shader
+	// PrepareCulling is called once per frame for the shader to initialize culling calculation.
+	PrepareCulling()
+	ShouldDraw(*RenderComponent, *SpaceComponent) bool
+}
+
 type basicShader struct {
 	BatchSize int
 
@@ -102,6 +110,7 @@ type basicShader struct {
 	projectionMatrix *engo.Matrix
 	viewMatrix       *engo.Matrix
 	modelMatrix      *engo.Matrix
+	cullingMatrix    *engo.Matrix
 
 	camera        *CameraSystem
 	cameraEnabled bool
@@ -149,6 +158,8 @@ func (s *basicShader) Setup(w *ecs.World) error {
 	s.projectionMatrix = engo.IdentityMatrix()
 	s.viewMatrix = engo.IdentityMatrix()
 	s.modelMatrix = engo.IdentityMatrix()
+	s.cullingMatrix = engo.IdentityMatrix()
+
 	return nil
 }
 
@@ -161,6 +172,22 @@ func (s *basicShader) Pre() {
 	engo.Gl.EnableVertexAttribArray(s.inPosition)
 	engo.Gl.EnableVertexAttribArray(s.inTexCoords)
 	engo.Gl.EnableVertexAttribArray(s.inColor)
+
+	// The matrixProjView shader uniform is projection * view.
+	// We do the multiplication on the CPU instead of sending each matrix to the shader and letting the GPU do the multiplication,
+	// because it's likely faster to do the multiplication client side and send the result over the shader bus than to send two separate
+	// buffers over the bus and then do the multiplication on the GPU.
+	pv := s.projectionMatrix.Multiply(s.viewMatrix)
+	engo.Gl.UniformMatrix3fv(s.matrixProjView, false, pv.Val[:])
+
+	// Since we are batching client side, we only have one VBO, so we can just bind it now and use it for the entire frame.
+	engo.Gl.BindBuffer(engo.Gl.ARRAY_BUFFER, s.vertexBuffer)
+	engo.Gl.VertexAttribPointer(s.inPosition, 2, engo.Gl.FLOAT, false, 20, 0)
+	engo.Gl.VertexAttribPointer(s.inTexCoords, 2, engo.Gl.FLOAT, false, 20, 8)
+	engo.Gl.VertexAttribPointer(s.inColor, 4, engo.Gl.UNSIGNED_BYTE, true, 20, 16)
+}
+
+func (s *basicShader) PrepareCulling() {
 	// (Re)initialize the projection matrix.
 	s.projectionMatrix.Identity()
 	if engo.ScaleOnResize() {
@@ -177,18 +204,23 @@ func (s *basicShader) Pre() {
 		scaleX, scaleY := s.projectionMatrix.ScaleComponent()
 		s.viewMatrix.Translate(-1/scaleX, 1/scaleY)
 	}
-	// The matrixProjView shader uniform is projection * view.
-	// We do the multiplication on the CPU instead of sending each matrix to the shader and letting the GPU do the multiplication,
-	// because it's likely faster to do the multiplication client side and send the result over the shader bus than to send two separate
-	// buffers over the bus and then do the multiplication on the GPU.
-	pv := s.projectionMatrix.Multiply(s.viewMatrix)
-	engo.Gl.UniformMatrix3fv(s.matrixProjView, false, pv.Val[:])
+	s.cullingMatrix.Identity()
+	s.cullingMatrix.Multiply(s.projectionMatrix).Multiply(s.viewMatrix)
+	s.cullingMatrix.Scale(engo.GetGlobalScale().X, engo.GetGlobalScale().Y)
+}
 
-	// Since we are batching client side, we only have one VBO, so we can just bind it now and use it for the entire frame.
-	engo.Gl.BindBuffer(engo.Gl.ARRAY_BUFFER, s.vertexBuffer)
-	engo.Gl.VertexAttribPointer(s.inPosition, 2, engo.Gl.FLOAT, false, 20, 0)
-	engo.Gl.VertexAttribPointer(s.inTexCoords, 2, engo.Gl.FLOAT, false, 20, 8)
-	engo.Gl.VertexAttribPointer(s.inColor, 4, engo.Gl.UNSIGNED_BYTE, true, 20, 16)
+func (s *basicShader) ShouldDraw(rc *RenderComponent, sc *SpaceComponent) bool {
+	aabb := sc.AABB()
+	aabb.Min.Multiply(rc.Scale)
+	aabb.Max.Multiply(rc.Scale)
+
+	minVtx := engo.MultiplyMatrixVector(s.cullingMatrix, []float32{aabb.Min.X, aabb.Min.Y})
+	maxVtx := engo.MultiplyMatrixVector(s.cullingMatrix, []float32{aabb.Max.X, aabb.Max.Y})
+
+	return !((minVtx[0] < -1 && maxVtx[0] < -1) || // Both points left of the "viewport"
+		(minVtx[0] > 1 && maxVtx[0] > 1) || // Both points right of the "viewport"
+		(minVtx[1] < -1 && maxVtx[1] < -1) || // Both points above of the "viewport"
+		(minVtx[1] > 1 && maxVtx[1] > 1)) // Both points below of the "viewport"
 }
 
 func (s *basicShader) Draw(ren *RenderComponent, space *SpaceComponent) {

--- a/common/render_shaders.go
+++ b/common/render_shaders.go
@@ -172,7 +172,6 @@ func (s *basicShader) Pre() {
 	engo.Gl.EnableVertexAttribArray(s.inPosition)
 	engo.Gl.EnableVertexAttribArray(s.inTexCoords)
 	engo.Gl.EnableVertexAttribArray(s.inColor)
-	s.PrepareCulling()
 
 	// The matrixProjView shader uniform is projection * view.
 	// We do the multiplication on the CPU instead of sending each matrix to the shader and letting the GPU do the multiplication,

--- a/math.go
+++ b/math.go
@@ -520,3 +520,12 @@ func MultiplyMatrixVector(m *Matrix, v []float32) []float32 {
 	v20 := m.Val[m20]*v[m00] + m.Val[m21]*v[m10] + m.Val[m22]*v[m20]
 	return []float32{v00, v10, v20}
 }
+
+// MultiplyMatrixVector multiplies the matrix m with the point and returns the result.
+func (pt *Point) MultiplyMatrixVector(m *Matrix) *Point {
+	x := m.Val[m00]*pt.X + m.Val[m01]*pt.Y + m.Val[m02]
+	y := m.Val[m10]*pt.X + m.Val[m11]*pt.Y + m.Val[m12]
+	pt.X = x
+	pt.Y = y
+	return pt
+}


### PR DESCRIPTION
Hi,

after thinking about frustum culling for 2D, I've came up with this simple solution. I'm not 100% sure this is really faster so this needs to be tested.

If this could be optimized, it could be a performance gain. 
the cpu-profiler tells me that it spend 68% of all the `RenderSystem` time in `ShouldDraw` and 86% of that time is spend in `engo.MultiplyMatrixVector`
