### PR TITLE
fix channel closing and oto Context errors

### DIFF
--- a/common/audio_test.go
+++ b/common/audio_test.go
@@ -68,7 +68,7 @@ func TestAudioSystemIntegrationNormalUse(t *testing.T) {
 		NoRun:        true,
 		AssetsRoot:   "testdata",
 	}, &s)
-	p := s.audioSystem.otoPlayer.(*stepPlayer)
+	p := otoPlayer.(*stepPlayer)
 
 	s.w.Update(1)
 	exp := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}


### PR DESCRIPTION
when switching scenes with the audio system the channel wasn't closing, and trying to create a new player caused context panics in oto.