### PR TITLE
Change z-index to public

### DIFF
--- a/common/render.go
+++ b/common/render.go
@@ -5,6 +5,7 @@ import (
 	"github.com/EngoEngine/engo"
 	"github.com/EngoEngine/gl"
 	"image/color"
+	"reflect"
 	"sort"
 	"sync"
 	"unsafe"
@@ -159,8 +160,8 @@ func (r renderEntityList) Less(i, j int) bool {
 		return r[i].RenderComponent.zIndex < r[j].RenderComponent.zIndex
 	}
 
-	// TODO: optimize this for performance
-	p1, p2 := uintptr((*emptyInterface)(unsafe.Pointer(&r[i].RenderComponent.shader)).word), uintptr((*emptyInterface)(unsafe.Pointer(&r[j].RenderComponent.shader)).word)
+	// // TODO: optimize this for performance
+	p1, p2 := reflect.ValueOf(r[i].RenderComponent.shader).Pointer(), reflect.ValueOf(r[j].RenderComponent.shader).Pointer()
 	if p1 != p2 {
 		return p1 < p2
 	}
@@ -199,10 +200,6 @@ func (r renderEntityList) Less(i, j int) bool {
 
 func (r renderEntityList) Swap(i, j int) {
 	r[i], r[j] = r[j], r[i]
-}
-
-type emptyInterface struct {
-	word unsafe.Pointer
 }
 
 // RenderSystem is the system that draws entities on the OpenGL surface. It requires

--- a/common/render.go
+++ b/common/render.go
@@ -159,8 +159,7 @@ func (r renderEntityList) Less(i, j int) bool {
 		return r[i].RenderComponent.zIndex < r[j].RenderComponent.zIndex
 	}
 
-	// TODO: optimize this for performance (is it enough? maybe "cache" shader uintptr (i.e: r.shaderPtr)?)
-	p1, p2 := (*[2]uintptr)(unsafe.Pointer(&r[i].RenderComponent.shader))[1], (*[2]uintptr)(unsafe.Pointer(&r[j].RenderComponent.shader))[1]
+	p1, p2 := getShadersPtr(r[i].RenderComponent.shader, r[j].RenderComponent.shader)
 	if p1 != p2 {
 		return p1 < p2
 	}

--- a/common/render.go
+++ b/common/render.go
@@ -292,7 +292,9 @@ func (rs *RenderSystem) Add(basic *ecs.BasicEntity, render *RenderComponent, spa
 		render.Scale.Y = 1
 	}
 
-	render.zIndex = render.StartZIndex
+	if render.zIndex == 0 {
+		render.zIndex = render.StartZIndex
+	}
 
 	rs.entities = append(rs.entities, renderEntity{basic, render, space})
 	rs.sortingNeeded = true

--- a/common/render.go
+++ b/common/render.go
@@ -5,7 +5,6 @@ import (
 	"github.com/EngoEngine/engo"
 	"github.com/EngoEngine/gl"
 	"image/color"
-	"reflect"
 	"sort"
 	"sync"
 	"unsafe"
@@ -160,8 +159,8 @@ func (r renderEntityList) Less(i, j int) bool {
 		return r[i].RenderComponent.zIndex < r[j].RenderComponent.zIndex
 	}
 
-	// // TODO: optimize this for performance
-	p1, p2 := reflect.ValueOf(r[i].RenderComponent.shader).Pointer(), reflect.ValueOf(r[j].RenderComponent.shader).Pointer()
+	// TODO: optimize this for performance (is it enough? maybe "cache" shader uintptr (i.e: r.shaderPtr)?)
+	p1, p2 := (*[2]uintptr)(unsafe.Pointer(&r[i].RenderComponent.shader))[1], (*[2]uintptr)(unsafe.Pointer(&r[j].RenderComponent.shader))[1]
 	if p1 != p2 {
 		return p1 < p2
 	}

--- a/common/render.go
+++ b/common/render.go
@@ -80,11 +80,13 @@ type RenderComponent struct {
 	// BufferContent contains the buffer data
 	// Avoid using it unless your are writing a custom shader
 	BufferContent []float32
+	// ZIndex defines the order which the content is drawn to the screen. Higher z-indices are drawn on top of
+	// lower ones if men overlap.
+	ZIndex float32
 
 	magFilter, minFilter ZoomFilter
 
 	shader Shader
-	zIndex float32
 }
 
 // SetShader sets the shader used by the RenderComponent.
@@ -123,7 +125,7 @@ func (r *RenderComponent) Shader() Shader {
 // SetZIndex sets the order that the RenderComponent is drawn to the screen. Higher z-indices are drawn on top of
 // lower ones if they overlap.
 func (r *RenderComponent) SetZIndex(index float32) {
-	r.zIndex = index
+	r.ZIndex = index
 	engo.Mailbox.Dispatch(&renderChangeMessage{})
 }
 
@@ -153,7 +155,7 @@ func (r renderEntityList) Len() int {
 
 func (r renderEntityList) Less(i, j int) bool {
 	// Sort by shader-pointer if they have the same zIndex
-	if r[i].RenderComponent.zIndex == r[j].RenderComponent.zIndex {
+	if r[i].RenderComponent.ZIndex == r[j].RenderComponent.ZIndex {
 		// // TODO: optimize this for performance
 		p1 := fmt.Sprintf("%p", r[i].RenderComponent.shader)
 		p2 := fmt.Sprintf("%p", r[j].RenderComponent.shader)
@@ -209,7 +211,7 @@ func (r renderEntityList) Less(i, j int) bool {
 		return p1 < p2
 	}
 
-	return r[i].RenderComponent.zIndex < r[j].RenderComponent.zIndex
+	return r[i].RenderComponent.ZIndex < r[j].RenderComponent.ZIndex
 }
 
 func (r renderEntityList) Swap(i, j int) {

--- a/common/render_js.go
+++ b/common/render_js.go
@@ -2,6 +2,12 @@
 
 package common
 
+import "fmt"
+
+func getShadersPtr(a, b Shader) (string, string) {
+	return fmt.Sprintf("%p", a), fmt.Sprintf("%p", b)
+}
+
 func compareShaders(a, b Shader) bool {
 	return a == b
 }

--- a/common/render_notjs.go
+++ b/common/render_notjs.go
@@ -9,6 +9,10 @@ type iface struct {
 	Type, Data unsafe.Pointer
 }
 
+func getShadersPtr(a, b Shader) (uintptr, uintptr) {
+	return (*[2]uintptr)(unsafe.Pointer(&a))[1], (*[2]uintptr)(unsafe.Pointer(&b))[1]
+}
+
 func compareShaders(a, b Shader) bool {
 	// comparing the instances using unsafe pointers seems to be a little faster (about 0.007 ns on a "slow" machine)
 	// so using this unsafe method to compare shader != prevShader gives a nice performance boost when using many entities.


### PR DESCRIPTION
I'm not sure why, but the current version of Engo has a `zIndex` as private value. 

The only way to set ZIndex is by using `SetZIndex`, at the current version. That makes it impossible to set the value in advanced (at the `&RenderComponent{}`). In my case doesn't make any sense to set the ZIndex using the `SetZIndex`, since some elements have always the same ZIndex (like: background is 0 and player is 1).

I'm not aware of any issue of that change, but I don't know what wasn't public before.