### PR TITLE
Keep mouse drag when mouse action is neutral

### DIFF
--- a/common/mouse.go
+++ b/common/mouse.go
@@ -271,6 +271,13 @@ func (m *MouseSystem) Update(dt float32) {
 				if m.mouseDown && e.MouseComponent.rightStartedDragging {
 					e.MouseComponent.RightDragged = true
 				}
+			default:
+				if m.mouseDown && e.MouseComponent.startedDragging {
+					e.MouseComponent.Dragged = true
+				}
+				if m.mouseDown && e.MouseComponent.rightStartedDragging {
+					e.MouseComponent.RightDragged = true
+				}
 			}
 		} else {
 			if e.MouseComponent.Hovered {


### PR DESCRIPTION
Previously, when the mouse action was neutral, the `Dragged` state of the mouse was reset to `false`. This change fixes it by keeping it set to `true` as long as one of the mouse buttons is down, requiring a mouse release before the `Dragged` state is exited.  