### PR TITLE
Add support for Texture Atlases (spritesheets)

### DIFF
--- a/common/render_filetype.go
+++ b/common/render_filetype.go
@@ -22,6 +22,7 @@ import (
 	"github.com/EngoEngine/gl"
 )
 
+// imgLoader is the shared imageLoader for all image file formats
 var imgLoader *imageLoader
 
 // TextureResource is the resource used by the RenderSystem. It uses .jpg, .gif, and .png images

--- a/common/render_filetype.go
+++ b/common/render_filetype.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"image"
 	"image/draw"
+
 	// imported to decode jpegs and upload them to the GPU.
 	_ "image/jpeg"
 	// imported to decode .pngs and upload them to the GPU.
@@ -21,12 +22,15 @@ import (
 	"github.com/EngoEngine/gl"
 )
 
+var imgLoader *imageLoader
+
 // TextureResource is the resource used by the RenderSystem. It uses .jpg, .gif, and .png images
 type TextureResource struct {
-	Texture *gl.Texture
-	Width   float32
-	Height  float32
-	url     string
+	Texture  *gl.Texture
+	Width    float32
+	Height   float32
+	Viewport *engo.AABB
+	url      string
 }
 
 // URL is the file path of the TextureResource
@@ -172,7 +176,11 @@ func LoadedSprite(url string) (*Texture, error) {
 		return nil, fmt.Errorf("resource not of type `TextureResource`: %s", url)
 	}
 
-	return &Texture{img.Texture, img.Width, img.Height, engo.AABB{Max: engo.Point{X: 1.0, Y: 1.0}}}, nil
+	viewport := engo.AABB{Max: engo.Point{X: 1.0, Y: 1.0}}
+	if img.Viewport != nil {
+		viewport = *img.Viewport
+	}
+	return &Texture{img.Texture, img.Width, img.Height, viewport}, nil
 }
 
 // Texture represents a texture loaded in the GPU RAM (by using OpenGL), which defined dimensions and viewport
@@ -211,8 +219,9 @@ func (t Texture) Close() {
 }
 
 func init() {
-	engo.Files.Register(".jpg", &imageLoader{images: make(map[string]TextureResource)})
-	engo.Files.Register(".png", &imageLoader{images: make(map[string]TextureResource)})
-	engo.Files.Register(".gif", &imageLoader{images: make(map[string]TextureResource)})
-	engo.Files.Register(".svg", &imageLoader{images: make(map[string]TextureResource)})
+	imgLoader = &imageLoader{images: make(map[string]TextureResource)}
+	engo.Files.Register(".jpg", imgLoader)
+	engo.Files.Register(".png", imgLoader)
+	engo.Files.Register(".gif", imgLoader)
+	engo.Files.Register(".svg", imgLoader)
 }

--- a/common/texture_atlas.go
+++ b/common/texture_atlas.go
@@ -13,27 +13,37 @@ import (
 
 // TextureAtlas is a collection of small textures grouped into a big image
 type TextureAtlas struct {
-	XMLName     xml.Name     `xml:"TextureAtlas"`
-	Text        string       `xml:",chardata"`
-	ImagePath   string       `xml:"imagePath,attr"`
+	XMLName xml.Name `xml:"TextureAtlas"`
+	Text    string   `xml:",chardata"`
+	// ImagePath is the path of the main image all the textures will be derived from
+	ImagePath string `xml:"imagePath,attr"`
+	// SubTextures is a slice of SubTextures
 	SubTextures []SubTexture `xml:"SubTexture"`
 }
 
 // SubTexture represents a texture from a region in the TextureAtlas
 type SubTexture struct {
-	Text   string  `xml:",chardata"`
-	Name   string  `xml:"name,attr"`
-	X      float32 `xml:"x,attr"`
-	Y      float32 `xml:"y,attr"`
-	Width  float32 `xml:"width,attr"`
+	Text string `xml:",chardata"`
+	// Name is the location of the subtexture before it was packed, Used as the url in the image loader
+	Name string `xml:"name,attr"`
+	// X coordinate of the subtexture in reference to the main image
+	X float32 `xml:"x,attr"`
+	// Y coordinate of the subtexture in reference to the main image
+	Y float32 `xml:"y,attr"`
+	// Width of the subtexture in reference to the main image
+	Width float32 `xml:"width,attr"`
+	// Height of the subtexture in reference to the main image
 	Height float32 `xml:"height,attr"`
 }
 
+// TextureAtlasResource contains reference to a loaded TextureAtlas and the texture of the main image
 type TextureAtlasResource struct {
-	texture *gl.Texture     // The original texture
-	cache   map[int]Texture // The cell cache cells
-	url     string
-	Atlas   *TextureAtlas
+	// texture is a gl.Texture reference of the main image
+	texture *gl.Texture
+	// url is the location of the xml file
+	url string
+	// Atlas is the TextureAtlas filled with data from the parsed XML file
+	Atlas *TextureAtlas
 }
 
 // URL retrieves the url to the .xml file
@@ -41,10 +51,17 @@ func (r TextureAtlasResource) URL() string {
 	return r.url
 }
 
+// textureAtlasLoader is reponsible for managing '.xml' files exported from TexturePacker (https://www.codeandweb.com/texturepacker)
 type textureAtlasLoader struct {
 	atlases map[string]*TextureAtlasResource
 }
 
+// Load will load the xml file and the main image as well as add references
+// for sub textures/images in engo.Files
+// For example this sub texture:
+//  <SubTexture name="subimg.png" x="10" y="10" width="50" height="50"/>
+// can be retrieved with this go code
+//  texture, err := common.LoadedSprite("subimg.png")
 func (t *textureAtlasLoader) Load(url string, data io.Reader) error {
 	atlas, err := createAtlasFromXML(data, url)
 	if err != nil {
@@ -55,11 +72,23 @@ func (t *textureAtlasLoader) Load(url string, data io.Reader) error {
 	return nil
 }
 
+// Unload removes the preloaded atlass from the cache and clears
+// references to all SubTextures from the image loader
 func (t *textureAtlasLoader) Unload(url string) error {
+	if err := imgLoader.Unload(t.atlases[url].Atlas.ImagePath); err != nil {
+		return err
+	}
+	for _, subTexture := range t.atlases[url].Atlas.SubTextures {
+		if err := imgLoader.Unload(subTexture.Name); err != nil {
+			return err
+		}
+	}
+
 	delete(t.atlases, url)
 	return nil
 }
 
+// Resource retrieves and returns the texture atlas of type TextureAtlasResource
 func (t *textureAtlasLoader) Resource(url string) (engo.Resource, error) {
 	atlas, ok := t.atlases[url]
 	if !ok {
@@ -69,6 +98,8 @@ func (t *textureAtlasLoader) Resource(url string) (engo.Resource, error) {
 	return atlas, nil
 }
 
+// createAtlasFromXML unmarshals and unpacks the xml data into a TextureAtlas
+// it also adds the main image and subtextures to the imageLoader
 func createAtlasFromXML(r io.Reader, url string) (*TextureAtlasResource, error) {
 	var atlas *TextureAtlas
 	data, err := ioutil.ReadAll(r)

--- a/common/texture_atlas.go
+++ b/common/texture_atlas.go
@@ -4,7 +4,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"path"
 
 	"github.com/EngoEngine/engo"
@@ -102,11 +101,7 @@ func (t *textureAtlasLoader) Resource(url string) (engo.Resource, error) {
 // it also adds the main image and subtextures to the imageLoader
 func createAtlasFromXML(r io.Reader, url string) (*TextureAtlasResource, error) {
 	var atlas *TextureAtlas
-	data, err := ioutil.ReadAll(r)
-	if err != nil {
-		return nil, err
-	}
-	err = xml.Unmarshal(data, &atlas)
+	err := xml.NewDecoder(r).Decode(&atlas)
 	if err != nil {
 		return nil, err
 	}

--- a/common/texture_atlas.go
+++ b/common/texture_atlas.go
@@ -1,0 +1,128 @@
+package common
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"path"
+
+	"github.com/EngoEngine/engo"
+	"github.com/EngoEngine/gl"
+)
+
+// TextureAtlas is a collection of small textures grouped into a big image
+type TextureAtlas struct {
+	XMLName     xml.Name     `xml:"TextureAtlas"`
+	Text        string       `xml:",chardata"`
+	ImagePath   string       `xml:"imagePath,attr"`
+	SubTextures []SubTexture `xml:"SubTexture"`
+}
+
+// SubTexture represents a texture from a region in the TextureAtlas
+type SubTexture struct {
+	Text   string  `xml:",chardata"`
+	Name   string  `xml:"name,attr"`
+	X      float32 `xml:"x,attr"`
+	Y      float32 `xml:"y,attr"`
+	Width  float32 `xml:"width,attr"`
+	Height float32 `xml:"height,attr"`
+}
+
+type TextureAtlasResource struct {
+	texture *gl.Texture     // The original texture
+	cache   map[int]Texture // The cell cache cells
+	url     string
+	Atlas   *TextureAtlas
+}
+
+// URL retrieves the url to the .xml file
+func (r TextureAtlasResource) URL() string {
+	return r.url
+}
+
+type textureAtlasLoader struct {
+	atlases map[string]*TextureAtlasResource
+}
+
+func (t *textureAtlasLoader) Load(url string, data io.Reader) error {
+	atlas, err := createAtlasFromXML(data, url)
+	if err != nil {
+		return err
+	}
+
+	t.atlases[url] = atlas
+	return nil
+}
+
+func (t *textureAtlasLoader) Unload(url string) error {
+	delete(t.atlases, url)
+	return nil
+}
+
+func (t *textureAtlasLoader) Resource(url string) (engo.Resource, error) {
+	atlas, ok := t.atlases[url]
+	if !ok {
+		return nil, fmt.Errorf("resource not loaded by `FileLoader`: %q", url)
+	}
+
+	return atlas, nil
+}
+
+func createAtlasFromXML(r io.Reader, url string) (*TextureAtlasResource, error) {
+	var atlas *TextureAtlas
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	err = xml.Unmarshal(data, &atlas)
+	if err != nil {
+		return nil, err
+	}
+
+	imgURL := path.Join(path.Dir(url), atlas.ImagePath)
+	if err := engo.Files.Load(imgURL); err != nil {
+		return nil, fmt.Errorf("failed load texture atlas image: %v", err)
+	}
+
+	res, err := engo.Files.Resource(imgURL)
+	if err != nil {
+		return nil, err
+	}
+
+	img, ok := res.(TextureResource)
+	if !ok {
+		return nil, fmt.Errorf("resource not of type `TextureResource`: %v", url)
+	}
+
+	for _, subTexture := range atlas.SubTextures {
+		texture := &Texture{
+			id:     img.Texture,
+			width:  subTexture.Width,
+			height: subTexture.Height,
+		}
+
+		viewport := engo.AABB{
+			Min: engo.Point{
+				X: subTexture.X / img.Width,
+				Y: subTexture.Y / img.Height,
+			},
+			Max: engo.Point{
+				X: (subTexture.X + subTexture.Width) / img.Width,
+				Y: (subTexture.Y + subTexture.Height) / img.Height,
+			},
+		}
+
+		imgLoader.images[subTexture.Name] = TextureResource{Texture: texture.id, Width: texture.width, Height: texture.height, Viewport: &viewport}
+	}
+
+	return &TextureAtlasResource{
+		Atlas:   atlas,
+		url:     url,
+		texture: img.Texture,
+	}, nil
+}
+
+func init() {
+	engo.Files.Register(".xml", &textureAtlasLoader{atlases: make(map[string]*TextureAtlasResource)})
+}


### PR DESCRIPTION
- Add TextureAtlas loader to the File Loader based on xml exports from [TexturePacker](https://www.codeandweb.com/texturepacker)
- Make it the default loader for xml files
- Use a singular `ImageLoader` object for `engo.Files` to save memory allocations
- Add Viewport to `TextureResource` and use it if defined in `LoadedSprite(..)`
     - Allows the use of the singular sprite sheet texture because singular sprites will be retrieved from the viewport of it

I tried to make it so that users can continue using `common.LoadedSprite` regardless of if they're using a `TextureAtlas` or not. This means that the texture is added to the image loader manually and is referenced using the file url for it.

For example: 
`<SubTexture name="enemyGreen1.png" x="425" y="552" width="93" height="84"/>`

That sprite can be retrieved using 

`texture, err := common.LoadedSprite("enemyGreen1.png")` even though it wasn't loaded from that location in the file-system but loaded from the singular sprite sheet image defined in the xml file.

Tested using: [these files](https://github.com/otraore/space-shooter/tree/master/assets/spritesheets)
I am open to suggestions

In progress: needs review, tests
Closes #707 