### PR TITLE
no longer js.Value compare using ==

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - 1.13.x
+          - 1.14.x
         platform:
           - { on: ubuntu-18.04, name: linux, type: desktop }
           - { on: ubuntu-18.04, name: linux, type: browser }

--- a/engo_js.go
+++ b/engo_js.go
@@ -42,7 +42,7 @@ func CreateWindow(title string, width, height int, fullscreen bool, msaa int) {
 	canvas.Set("width", int(float64(width)+0.5))   // Nearest non-negative int.
 	canvas.Set("height", int(float64(height)+0.5)) // Nearest non-negative int.
 
-	if document.Get("body") == js.Null() {
+	if document.Get("body").IsNull() {
 		document.Set("body", document.Call("createElement", "body"))
 	}
 	body := document.Get("body")


### PR DESCRIPTION
syscall/js no longer supports using straight == to compre js values.