### PR TITLE
Input key modifiers

### DIFF
--- a/engo_glfw.go
+++ b/engo_glfw.go
@@ -175,6 +175,8 @@ func CreateWindow(title string, width, height int, fullscreen bool, msaa int) {
 		} else if a == glfw.Release {
 			Input.keys.Set(key, false)
 		}
+
+		Input.Modifier = Modifier(m)
 	})
 
 	Window.SetSizeCallback(func(w *glfw.Window, widthInt int, heightInt int) {

--- a/engo_sdl.go
+++ b/engo_sdl.go
@@ -139,6 +139,20 @@ func RunIteration() {
 				} else if e.GetType() == sdl.KEYDOWN {
 					Input.keys.Set(key, true)
 				}
+				Input.Modifier = Modifier(sdl.GetModState())
+
+				// SDL supports codes for both left/right mods, to keep the API similar
+				// with the GLFW implementation, either will trigger the mod for that key
+				if Input.Modifier&sdl.KMOD_SHIFT != 0 {
+					Input.Modifier = Shift
+				} else if Input.Modifier&sdl.KMOD_CTRL != 0 {
+					Input.Modifier = Control
+				} else if Input.Modifier&sdl.KMOD_ALT != 0 {
+					Input.Modifier = Alt
+				} else if Input.Modifier&sdl.KMOD_GUI != 0 {
+					Input.Modifier = Super
+				}
+
 			case *sdl.MouseWheelEvent:
 				Input.Mouse.ScrollX = float32(e.X)
 				Input.Mouse.ScrollY = float32(e.Y)
@@ -158,8 +172,7 @@ func RunIteration() {
 					Input.Mouse.Button = MouseButton5
 				}
 
-				// Is this possible in SDL?
-				// Input.Mouse.Modifer = Modifier(m)
+				Input.Mouse.Modifer = Input.Modifier
 
 				if e.State == sdl.PRESSED {
 					Input.Mouse.Action = Press

--- a/input.go
+++ b/input.go
@@ -24,6 +24,8 @@ type InputManager struct {
 	// Mouse is InputManager's reference to the mouse. It is recommended to use the
 	// Axis and Button system if at all possible.
 	Mouse Mouse
+	// Modifier represents a special key pressed along with another key
+	Modifier Modifier
 
 	// Touches is the touches on the screen. There can be up to 5 recorded in Android,
 	// and up to 4 on iOS. GLFW can also keep track of the touches. The latest touch is also

--- a/input_keys.go
+++ b/input_keys.go
@@ -214,6 +214,13 @@ const (
 	KeyNumEnter Key = 13
 )
 
+var jsStrToMod = map[string]Modifier{
+	"shiftKey": Shift,
+	"ctrlKey":  Control,
+	"altKey":   Alt,
+	"metaKey":  Super,
+}
+
 var jsStrToKey = map[string]Key{
 	"Escape":         KeyEscape,
 	"Digit0":         KeyZero,


### PR DESCRIPTION
Something to note is that SDL supports modifiers being identifiable by their position on the keyboard. So left shift vs right shift. GLFW as far as I know, does not. To keep the API simple and not requiring the end users to use bitwise operations to check their Modifiers, I just did the checks within the game loop so the API is the same for both platforms. Going to be adding js support in an upcoming commit as well.

ex:
```go
if engo.Input.Modifier == engo.Shift {
    log.Println("is shift")
}
```