### PR TITLE
Removed fallthrough case since it caused build errors

### DIFF
--- a/engo_empty.go
+++ b/engo_empty.go
@@ -75,8 +75,6 @@ func runLoop(defaultScene Scene, headless bool) {
 		case <-resetLoopTicker:
 			ticker.Stop()
 			ticker = time.NewTicker(time.Duration(int(time.Second) / opts.FPSLimit))
-		case <-c:
-			fallthrough
 		case <-closeGame:
 			ticker.Stop()
 			closeEvent()


### PR DESCRIPTION
I removed the fallthrough statement. Otherwise it already looked like the glfw version, so I think this should be the necessary changes to fix the compile error I received in #738 

There is still another problem with the headless build: The oto dependency is causing trouble, if no drivers are installed on a build system. But I'm not sure if this should be fixed in this pull request (or even in this repository)