### PR TITLE
remove buffer from actual atlas height

### DIFF
--- a/common/font.go
+++ b/common/font.go
@@ -211,7 +211,7 @@ func (f *Font) generateFontAtlas(c int) FontAtlas {
 		currentX += xBuffer
 
 		atlas.Width[i] = float32(adv.Ceil())
-		atlas.Height[i] = float32(lineHeight.Ceil()) + lineBuffer
+		atlas.Height[i] = float32(lineHeight.Ceil())
 		atlas.XLocation[i] = currentX
 		atlas.YLocation[i] = currentY
 


### PR DESCRIPTION
The fonts had a lot of height whitespace, and the height was always much bigger than the printed text.