### PR TITLE
Added support for tile animations from TMX files

### DIFF
--- a/common/level.go
+++ b/common/level.go
@@ -35,6 +35,7 @@ type Level struct {
 	Properties  []Property
 	resourceMap map[uint32]Texture
 	pointMap    map[mapPoint]*Tile
+	framesMap   map[uint32][]uint32
 }
 
 // Property is any custom property. The Type corresponds to the type (int,
@@ -277,5 +278,7 @@ func (t *Tile) View() (float32, float32, float32, float32) {
 // Tile represents a tile in the TMX map.
 type Tile struct {
 	engo.Point
-	Image *Texture
+	Image     *Texture
+	Drawables []Drawable
+	Animation *Animation
 }


### PR DESCRIPTION
This adds support for tile animations created in editors like Tiled and saved into the TMX files.

Currently, I have not found a good way to use the animation rate set in the editor, so that must be set when using the tile later and creating an AnimationComponent.

Here is an example of how to then implement the animation:
```go

tiles := []*Tile{}
for idx, layer := range level.TileLayers {
	for _, tile := range layer.Tiles {
		if tile.Image == nil {
			log.Printf("Tile has no image at point: %v", tile.Point)
		}
		t := &Tile{BasicEntity: ecs.NewBasic()}
		if len(tile.Drawables) > 0 {
			t.AnimationComponent = common.NewAnimationComponent(tile.Drawables, 0.1)
			t.AnimationComponent.AddDefaultAnimation(tile.Animation)
		}
		t.RenderComponent = common.RenderComponent{
			Drawable:    tile.Image,
			Scale:       engo.Point{X: 1, Y: 1},
			StartZIndex: float32(idx),
		}
		t.SpaceComponent = common.SpaceComponent{
			Position: tile.Point,
		}
		tiles = append(tiles, t)
	}
}

```