### PR TITLE
Double drawing and proper number of verts

### DIFF
--- a/common/render_shaders_shapes.go
+++ b/common/render_shaders_shapes.go
@@ -152,7 +152,7 @@ func (l *legacyShader) computeBufferSize(draw Drawable) int {
 	case Rectangle:
 		return 90
 	case Circle:
-		return 2160
+		return 3240
 	case ComplexTriangles:
 		return len(shape.Points) * 6
 	case Curve:
@@ -288,7 +288,7 @@ func (l *legacyShader) generateBufferContent(ren *RenderComponent, space *SpaceC
 		setBufferValue(buffer, 1, h/2, &changed)
 		setBufferValue(buffer, 2, tint, &changed)
 		if hasBorder {
-			setBufferValue(buffer, 1080, w/2, &changed)
+			setBufferValue(buffer, 1080, w-bx, &changed)
 			setBufferValue(buffer, 1081, h/2, &changed)
 			setBufferValue(buffer, 1082, borderTint, &changed)
 		}
@@ -298,9 +298,12 @@ func (l *legacyShader) generateBufferContent(ren *RenderComponent, space *SpaceC
 			setBufferValue(buffer, i*3+1, cy+(cy-by)*s, &changed)
 			setBufferValue(buffer, i*3+2, tint, &changed)
 			if hasBorder {
-				setBufferValue(buffer, i*3+1080, cx+cx*c, &changed)
-				setBufferValue(buffer, i*3+1081, cy+cy*s, &changed)
-				setBufferValue(buffer, i*3+1082, borderTint, &changed)
+				setBufferValue(buffer, i*6+1080, cx+cx*c, &changed)
+				setBufferValue(buffer, i*6+1081, cy+cy*s, &changed)
+				setBufferValue(buffer, i*6+1082, borderTint, &changed)
+				setBufferValue(buffer, i*6+1083, cx+(cx-bx)*c, &changed)
+				setBufferValue(buffer, i*6+1084, cy+(cy-by)*s, &changed)
+				setBufferValue(buffer, i*6+1085, borderTint, &changed)
 			}
 		}
 
@@ -530,11 +533,7 @@ func (l *legacyShader) Draw(ren *RenderComponent, space *SpaceComponent) {
 		engo.Gl.DrawArrays(engo.Gl.TRIANGLES, 0, num)
 	case Circle:
 		if shape.BorderWidth > 0 {
-			if engo.FloatEqual(shape.Arc, 360) || engo.FloatEqual(shape.Arc, 0) {
-				engo.Gl.DrawArrays(engo.Gl.TRIANGLE_FAN, 360, 360)
-			} else {
-				engo.Gl.DrawArrays(engo.Gl.TRIANGLE_FAN, 360, 355)
-			}
+			engo.Gl.DrawArrays(engo.Gl.TRIANGLE_STRIP, 362, 718)
 		}
 		engo.Gl.DrawArrays(engo.Gl.TRIANGLE_FAN, 0, 360)
 	case ComplexTriangles:

--- a/common/render_shaders_shapes.go
+++ b/common/render_shaders_shapes.go
@@ -152,7 +152,7 @@ func (l *legacyShader) computeBufferSize(draw Drawable) int {
 	case Rectangle:
 		return 90
 	case Circle:
-		return 3240
+		return 3260
 	case ComplexTriangles:
 		return len(shape.Points) * 6
 	case Curve:
@@ -274,7 +274,7 @@ func (l *legacyShader) generateBufferContent(ren *RenderComponent, space *SpaceC
 		if shape.Arc == 0 {
 			shape.Arc = 360
 		}
-		theta := float32(2.0*math.Pi/355.0) * shape.Arc / 360
+		theta := float32(2.0*math.Pi/360.0) * shape.Arc / 360
 		cx := w / 2
 		bx := shape.BorderWidth
 		cy := h / 2
@@ -288,22 +288,22 @@ func (l *legacyShader) generateBufferContent(ren *RenderComponent, space *SpaceC
 		setBufferValue(buffer, 1, h/2, &changed)
 		setBufferValue(buffer, 2, tint, &changed)
 		if hasBorder {
-			setBufferValue(buffer, 1080, w-bx, &changed)
-			setBufferValue(buffer, 1081, h/2, &changed)
-			setBufferValue(buffer, 1082, borderTint, &changed)
+			setBufferValue(buffer, 1086, w-bx, &changed)
+			setBufferValue(buffer, 1087, h/2, &changed)
+			setBufferValue(buffer, 1088, borderTint, &changed)
 		}
-		for i := 1; i < 360; i++ {
+		for i := 1; i < 362; i++ {
 			s, c := math.Sincos(float32(i) * theta)
 			setBufferValue(buffer, i*3, cx+(cx-bx)*c, &changed)
 			setBufferValue(buffer, i*3+1, cy+(cy-by)*s, &changed)
 			setBufferValue(buffer, i*3+2, tint, &changed)
 			if hasBorder {
-				setBufferValue(buffer, i*6+1080, cx+cx*c, &changed)
-				setBufferValue(buffer, i*6+1081, cy+cy*s, &changed)
-				setBufferValue(buffer, i*6+1082, borderTint, &changed)
-				setBufferValue(buffer, i*6+1083, cx+(cx-bx)*c, &changed)
-				setBufferValue(buffer, i*6+1084, cy+(cy-by)*s, &changed)
-				setBufferValue(buffer, i*6+1085, borderTint, &changed)
+				setBufferValue(buffer, i*6+1086, cx+cx*c, &changed)
+				setBufferValue(buffer, i*6+1087, cy+cy*s, &changed)
+				setBufferValue(buffer, i*6+1088, borderTint, &changed)
+				setBufferValue(buffer, i*6+1089, cx+(cx-bx)*c, &changed)
+				setBufferValue(buffer, i*6+1090, cy+(cy-by)*s, &changed)
+				setBufferValue(buffer, i*6+1091, borderTint, &changed)
 			}
 		}
 
@@ -533,9 +533,9 @@ func (l *legacyShader) Draw(ren *RenderComponent, space *SpaceComponent) {
 		engo.Gl.DrawArrays(engo.Gl.TRIANGLES, 0, num)
 	case Circle:
 		if shape.BorderWidth > 0 {
-			engo.Gl.DrawArrays(engo.Gl.TRIANGLE_STRIP, 362, 718)
+			engo.Gl.DrawArrays(engo.Gl.TRIANGLE_STRIP, 364, 722)
 		}
-		engo.Gl.DrawArrays(engo.Gl.TRIANGLE_FAN, 0, 360)
+		engo.Gl.DrawArrays(engo.Gl.TRIANGLE_FAN, 0, 362)
 	case ComplexTriangles:
 		engo.Gl.DrawArrays(engo.Gl.TRIANGLES, 0, len(shape.Points))
 

--- a/demos/shapes/shapes.go
+++ b/demos/shapes/shapes.go
@@ -157,7 +157,7 @@ func (*DefaultScene) Setup(u engo.Updater) {
 
 	arc2 := MyShape{BasicEntity: ecs.NewBasic()}
 	arc2.SpaceComponent = common.SpaceComponent{Position: engo.Point{473, 323}, Width: 50, Height: 50}
-	arc2.RenderComponent = common.RenderComponent{Drawable: common.Circle{Arc: 45, BorderWidth: 1, BorderColor: color.White}, Color: color.RGBA{0, 0, 255, 255}}
+	arc2.RenderComponent = common.RenderComponent{Drawable: common.Circle{Arc: 180, BorderWidth: 1, BorderColor: color.White}, Color: color.RGBA{0, 0, 255, 255}}
 
 	for _, system := range w.Systems() {
 		switch sys := system.(type) {

--- a/demos/shapes/shapes.go
+++ b/demos/shapes/shapes.go
@@ -157,7 +157,7 @@ func (*DefaultScene) Setup(u engo.Updater) {
 
 	arc2 := MyShape{BasicEntity: ecs.NewBasic()}
 	arc2.SpaceComponent = common.SpaceComponent{Position: engo.Point{473, 323}, Width: 50, Height: 50}
-	arc2.RenderComponent = common.RenderComponent{Drawable: common.Circle{Arc: 180, BorderWidth: 1, BorderColor: color.White}, Color: color.RGBA{0, 0, 255, 255}}
+	arc2.RenderComponent = common.RenderComponent{Drawable: common.Circle{Arc: 45, BorderWidth: 1, BorderColor: color.White}, Color: color.RGBA{0, 0, 255, 255}}
 
 	for _, system := range w.Systems() {
 		switch sys := system.(type) {


### PR DESCRIPTION
I was counting the vertex that sets it to the center as a vertex that draws the circle, which led to an off-by-one offset in the circle. This caused the angles to be a little smaller than they should've been when using `Circle.Arc`, as well as double drawing of some triangles when the transparency was set to something other than 1 or 0.

Fixes for #766