### PR TITLE
tmx: fix the tmx/tsx loading

### DIFF
--- a/common/tmx_filetype.go
+++ b/common/tmx_filetype.go
@@ -23,11 +23,16 @@ func (r TMXResource) URL() string {
 // You can generate a TMX file with the Tiled map editor.
 type tmxLoader struct {
 	levels map[string]TMXResource
+	root string
+}
+
+func (t *tmxLoader) SetRoot(root string) {
+	t.root = root	
 }
 
 // Load will load the tmx file and any other image resources that are needed
 func (t *tmxLoader) Load(url string, data io.Reader) error {
-	lvl, err := createLevelFromTmx(data, url)
+	lvl, err := createLevelFromTmx(data, url, t.root)
 	if err != nil {
 		return err
 	}

--- a/common/tmx_level.go
+++ b/common/tmx_level.go
@@ -1,8 +1,10 @@
 package common
 
 import (
+	"errors"
 	"io"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -11,8 +13,11 @@ import (
 )
 
 // createLevelFromTmx unmarshalls and unpacks tmx data into a Level
-func createLevelFromTmx(r io.Reader, tmxURL string) (*Level, error) {
-	tmx.TMXURL = tmxURL
+func createLevelFromTmx(r io.Reader, tmxURL string, root string) (*Level, error) {
+	if root == "" {
+		return nil, errors.New("createLevelFromTmx should be called with a real root")
+	}
+	tmx.TMXURL = filepath.Join(root, tmxURL)
 	tmxLevel, err := tmx.Parse(r)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Hello,

this little patch fixes an issue when trying to load tmx files that reference tsx files

it tries to be as unobtrusive as possible by defining a new interface and only using it if the given file loader supports this new interface.

Cheers,
Florent