### PR TITLE
Add rotation based on TMX flipping flag

### DIFF
--- a/common/level.go
+++ b/common/level.go
@@ -281,4 +281,6 @@ type Tile struct {
 	Image     *Texture
 	Drawables []Drawable
 	Animation *Animation
+	// Rotation of the Tile in degrees
+	Rotation float32
 }

--- a/common/tmx_level.go
+++ b/common/tmx_level.go
@@ -257,6 +257,7 @@ func (l *Level) unpackTiles(x, y, w, h int, d []tmx.Data) []*Tile {
 				X: float32(x),
 				Y: float32(y),
 			}))
+			tile.Rotation = convertFlipToRotation(t.Flipping)
 			ret = append(ret, tile)
 			l.pointMap[mapPoint{X: x, Y: y}] = tile
 			switch l.RenderOrder {
@@ -303,6 +304,7 @@ func (l *Level) unpackTiles(x, y, w, h int, d []tmx.Data) []*Tile {
 					X: float32(x),
 					Y: float32(y),
 				}))
+				tile.Rotation = convertFlipToRotation(t.Flipping)
 				ret = append(ret, tile)
 				l.pointMap[mapPoint{X: x, Y: y}] = tile
 				switch l.RenderOrder {
@@ -382,6 +384,21 @@ func (l *Level) tileFromGID(gid uint32, pt engo.Point) *Tile {
 	ret.Animation = &Animation{Name: "Tile", Frames: frames, Loop: true}
 
 	return ret
+}
+
+func convertFlipToRotation(flipping uint32) float32 {
+	flip_h := (flipping % tmx.HorizontalFlipFlag) != 0
+	flip_v := (flipping & tmx.VerticalFlipFlag) != 0
+	flip_d := (flipping & tmx.DiagonalFlipFlag) != 0
+	rotation := float32(0.0)
+	if flip_d {
+		rotation = 90
+	}
+	if flip_h && flip_v {
+		rotation += 180
+	}
+
+	return rotation
 }
 
 func getProperties(props []tmx.Property) []Property {

--- a/common/tmx_level_test.go
+++ b/common/tmx_level_test.go
@@ -1,0 +1,40 @@
+package common
+
+import "testing"
+
+func TestConvertFlipToRotation(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    uint32
+		expected float32
+	}{
+		{
+			name:     "no flipping should be 0º rotation",
+			input:    0,
+			expected: 0,
+		},
+		{
+			name:     "flipping diagonally should be 90º rotation",
+			input:    2684354560,
+			expected: 90,
+		},
+		{
+			name:     "flipping horizontally and vertically should be 180º rotation",
+			input:    3221225472,
+			expected: 180,
+		},
+		{
+			name:     "flipping diagonally, horizontally and vertically should be 270º rotation",
+			input:    1610612736,
+			expected: 270,
+		},
+	}
+
+	for _, test := range tests {
+		actual := convertFlipToRotation(test.input)
+
+		if actual != test.expected {
+			t.Errorf("%s expected=%f ; got=%f", test.name, test.expected, actual)
+		}
+	}
+}

--- a/demos/adventure/adventure.go
+++ b/demos/adventure/adventure.go
@@ -64,7 +64,6 @@ type Tile struct {
 }
 
 func (*DefaultScene) Preload() {
-
 	// Load character model
 	engo.Files.Load(model)
 
@@ -222,7 +221,6 @@ func (scene *DefaultScene) Setup(u engo.Updater) {
 
 	for _, tileLayer := range levelData.TileLayers {
 		for _, tileElement := range tileLayer.Tiles {
-
 			if tileElement.Image != nil {
 				tile := &Tile{BasicEntity: ecs.NewBasic()}
 				tile.RenderComponent = common.RenderComponent{
@@ -231,9 +229,13 @@ func (scene *DefaultScene) Setup(u engo.Updater) {
 				}
 				tile.SpaceComponent = common.SpaceComponent{
 					Position: tileElement.Point,
-					Width:    0,
-					Height:   0,
+					Width:    tileElement.Width(),
+					Height:   tileElement.Height(),
 				}
+				// Rotation of tile around the center
+				center := tile.Center()
+				tile.Rotation = tileElement.Rotation
+				tile.SetCenter(center)
 
 				if tileLayer.Name == "grass" {
 					tile.RenderComponent.SetZIndex(0)
@@ -250,7 +252,6 @@ func (scene *DefaultScene) Setup(u engo.Updater) {
 
 	for _, imageLayer := range levelData.ImageLayers {
 		for _, imageElement := range imageLayer.Images {
-
 			if imageElement.Image != nil {
 				tile := &Tile{BasicEntity: ecs.NewBasic()}
 				tile.RenderComponent = common.RenderComponent{
@@ -401,7 +402,6 @@ func (s *SpeedSystem) Remove(basic ecs.BasicEntity) {
 }
 
 func (s *SpeedSystem) Update(dt float32) {
-
 	for _, e := range s.entities {
 		speed := engo.GameWidth() * dt
 		e.SpaceComponent.Position.X = e.SpaceComponent.Position.X + speed*e.SpeedComponent.Point.X
@@ -422,7 +422,6 @@ func (s *SpeedSystem) Update(dt float32) {
 			e.SpaceComponent.Position.X = widthLimit
 		}
 	}
-
 }
 
 type controlEntity struct {

--- a/demos/adventure/assets/example.tmx
+++ b/demos/adventure/assets/example.tmx
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="25" height="25" tilewidth="32" tileheight="32" nextobjectid="7">
+<map version="1.5" tiledversion="1.7.1" orientation="orthogonal" renderorder="right-down" width="25" height="25" tilewidth="32" tileheight="32" infinite="0" nextlayerid="4" nextobjectid="7">
  <tileset firstgid="1" name="ts1" tilewidth="32" tileheight="32" tilecount="72" columns="12">
   <image source="grass-tiles-2-small.png" width="384" height="192"/>
  </tileset>
  <tileset firstgid="73" name="ts3" tilewidth="32" tileheight="32" tilecount="64" columns="8">
   <image source="tree2-final.png" width="256" height="256"/>
  </tileset>
- <layer name="grass" width="25" height="25">
+ <layer id="1" name="grass" width="25" height="25">
   <data encoding="base64" compression="zlib">
-   eJztVcsOwzAIS3OH39nu+/9/Wic1kuXYJNp63AHRIoIxj+RorfVTDpBOenyzfVfHKXlp/kd7p/9hU/7ufJUv2wNifGzPBQ/MZ5zLy654VHV1vIZv0NkDsDpgj3Mh4jk+6FthBMXnWmCuiofD4Hpmm3k/IH83ly4+96OK0QGr6ofijTmjKB/sedUPjoUxcVbVjOM8VPu1mu8UeMOOfXHnMTeeI8c725zbas8dZ7WnYXxVPVTfsAaMkcLu7j+15ylE7Zea2YqHwlG+7l59bfJw9w/vdba5Prs8nCT5/MKjesf4rXB+iLUzB99qN88rHnfoO3nsvOd/HrV+A9pgE7E=
+   eJztVUkOgzAMDLmi+MpT2ns/wtN4Sp/WVMLSdDR2opZjD5bB2J6Ml7CUUmqXBaSS9me2z+rWxU7N72iv9O425R/FZ+dle4Mcb9t9wAPP43F22hWPrK4RL/dtFLsAVgVsj2siX8QHfTMMzLeV8uRa4FkVjwiD6+k+a8fw2BucP5rLKD/3I8tRASvrh+KN/FGUD/Y86wfncun1P3p9DqP4btv7tx1nYrRfo/n2muJuuB37EsUjX54j5r2Wz1nG+NGeR5x5Tzf4ruqjeHDfsAaMYcIe3X9qz02I2i81sxkPhaN8o3v1Mckjun9M4Ee7N+IRiZHPLzyy/xj/KyI/xJqZg291NM8jHlfoK3nM/M//PHL9AvxTF38=
   </data>
  </layer>
- <layer name="trees" width="25" height="25">
+ <layer id="2" name="trees" width="25" height="25">
   <data encoding="base64" compression="zlib">
    eJzt1VUOAkEURNFhebi7u7u7y7K5O+jX0xNCCJWcP5JXH12DZX0mbnjghQ9+BBBEyKEbYUQQRQxxJJBEyqF+aWSQRQ55FFBEyaF+ZVRQRQ11NNBES3FD2q+NDrrooY8Bhhgpbkj7jTHBFDPMscASK8UNab81Nthihz0OOOKkuCHtd8YFV9xwxwNPvBQ3TPpJY9JPGpfGb79969KYbF0ak61LY7J1aexuXeet2N2Szluxu6X/W5HH5H9Bml/57kryBi05aII=
   </data>
  </layer>
- <imagelayer name="clouds">
+ <imagelayer id="3" name="clouds">
   <image source="cloud.png" width="400" height="218"/>
  </imagelayer>
 </map>


### PR DESCRIPTION


When working on my project I noticed that Engo is losing the information about flipped tiles in the tile map when converting from the TMX structure to the internal model. This pull request adds this feature by the means of adding a Rotation in degree to the internal TMX Tile model. I just now went this path, if this is in some way not how you intend to solve this problem, please let me know 🚀  I hope this is also in your interest and thank you for this really fun 2D engine!

This adds also a changed map to the `adventure` demo with 4 rotated flowers on the ground.
<img width="612" alt="Screenshot 2021-08-05 at 01 21 44" src="https://user-images.githubusercontent.com/5249233/128267849-265156ba-c436-495a-aa0d-76b2acb74785.png">
fixes #779