### PR TITLE
Correctly build gamepads_empty.go for mobile.

### DIFF
--- a/gamepads_empty.go
+++ b/gamepads_empty.go
@@ -1,4 +1,5 @@
-// +build headless,ios,android,vulkan,sdl
+//go:build headless || ios || android || vulkan || sdl
+// +build headless ios android vulkan sdl
 
 package engo
 


### PR DESCRIPTION
- This is required for newer Go versions.
- Help with compiling code for mobile.